### PR TITLE
changed email address associated with new sign-up to volunteer@slu.edu

### DIFF
--- a/client_app/src/Shelters.js
+++ b/client_app/src/Shelters.js
@@ -75,7 +75,7 @@ const Shelters = (props) => {
       body: JSON.stringify(shifts),
       headers: {
         "Content-type": "application/json; charset=UTF-8",
-        Authorization: "submitted-volunteer@slu.edu",
+        Authorization: "volunteer@slu.edu",
       },
     })
       .then(() => alert("You have submitted the shifts successfully"))


### PR DESCRIPTION
We temporarily have hard coded an email address to the client side application, in place of authentication. The email address associated with listing upcoming and previous shifts was volunteer@slu.edu, but the email address associated with new sign-ups was submitted-volunteer@slu.edu. This resulted in new sign-ups not showing up on the list of upcoming/previous shifts. Email volunteer@slu.edu is now used consistently throughout the application. Note, that this will be changed in the future to use proper authentication.