### PR TITLE
added facility info

### DIFF
--- a/server/application/rest/work_shift.py
+++ b/server/application/rest/work_shift.py
@@ -93,12 +93,13 @@ def work_shifts():
             enriched_shifts = []
             for work_shift in response.value:
                 # Convert the WorkShift object to JSON
-                work_shift_json = json.loads(json.dumps(work_shift, cls=WorkShiftJsonEncoder))
-                facility_response = get_facility_info_use_case(work_shift_json['shelter'])               
+                work_shift_json = json.loads(json.dumps(work_shift,
+                                                    cls=WorkShiftJsonEncoder))
+                facility_response = get_facility_info_use_case(work_shift_json['shelter'])        
                 if isinstance(facility_response, ResponseSuccess):
-                    work_shift_json['facility_info'] = facility_response.value
+                    work_shift_json["facility_info"]=facility_response.value
                 else:
-                    work_shift_json['facility_info'] = 'Facility information could not be retrieved'             
+                    work_shift_json["facility_info"]="Facilityinformation could not be retrieved"  
                 enriched_shifts.append(work_shift_json)
             return Response(
                 json.dumps(enriched_shifts),

--- a/server/application/rest/work_shift.py
+++ b/server/application/rest/work_shift.py
@@ -93,11 +93,13 @@ def work_shifts():
                 # Convert the WorkShift object to JSON
                 work_shift_json = json.loads(json.dumps(work_shift,
                                                     cls=WorkShiftJsonEncoder))
-                facility_response = get_facility_info_use_case(work_shift_json["shelter"])
+                facility_response = get_facility_info_use_case(
+                    work_shift_json["shelter"])
                 if isinstance(facility_response, ResponseSuccess):
                     work_shift_json["facility_info"]=facility_response.value
                 else:
-                    work_shift_json["facility_info"]="Facilityinformation could not be retrieved"
+                    work_shift_json["facility_info"]=\
+                    "Facilityinformation could not be retrieved"
                 enriched_shifts.append(work_shift_json)
             return Response(
                 json.dumps(enriched_shifts),

--- a/server/application/rest/work_shift.py
+++ b/server/application/rest/work_shift.py
@@ -10,12 +10,11 @@ from use_cases.list_workshifts import workshift_list_use_case
 from use_cases.add_workshifts import workshift_add_multiple_use_case
 from use_cases.delete_workshifts import delete_shift_use_case
 from use_cases.count_volunteers import count_volunteers_use_case
-from serializers.work_shift import WorkShiftJsonEncoder
-from requests.work_shift_list import build_work_shift_list_request
-from responses import ResponseTypes, ResponseSuccess, ResponseFailure
 from use_cases.get_facility_info import get_facility_info_use_case
+from serializers.work_shift import WorkShiftJsonEncoder
 from serializers.staffing import StaffingJsonEncoder
-from responses import ResponseTypes
+from responses import ResponseTypes, ResponseSuccess
+from requests.work_shift_list import build_work_shift_list_request
 from application.rest.request_from_params import list_shift_request
 
 blueprint = Blueprint("work_shift", __name__)
@@ -95,11 +94,11 @@ def work_shifts():
                 # Convert the WorkShift object to JSON
                 work_shift_json = json.loads(json.dumps(work_shift,
                                                     cls=WorkShiftJsonEncoder))
-                facility_response = get_facility_info_use_case(work_shift_json['shelter'])        
+                facility_response = get_facility_info_use_case(work_shift_json["shelter"])
                 if isinstance(facility_response, ResponseSuccess):
                     work_shift_json["facility_info"]=facility_response.value
                 else:
-                    work_shift_json["facility_info"]="Facilityinformation could not be retrieved"  
+                    work_shift_json["facility_info"]="Facilityinformation could not be retrieved"
                 enriched_shifts.append(work_shift_json)
             return Response(
                 json.dumps(enriched_shifts),

--- a/server/application/rest/work_shift.py
+++ b/server/application/rest/work_shift.py
@@ -13,7 +13,7 @@ from use_cases.count_volunteers import count_volunteers_use_case
 from use_cases.get_facility_info import get_facility_info_use_case
 from serializers.work_shift import WorkShiftJsonEncoder
 from serializers.staffing import StaffingJsonEncoder
-from responses import ResponseTypes, ResponseSuccess
+from responses import ResponseTypes
 from application.rest.request_from_params import list_shift_request
 
 blueprint = Blueprint("work_shift", __name__)

--- a/server/application/rest/work_shift.py
+++ b/server/application/rest/work_shift.py
@@ -95,11 +95,11 @@ def work_shifts():
                                                     cls=WorkShiftJsonEncoder))
                 facility_response = get_facility_info_use_case(
                     work_shift_json["shelter"])
-                if isinstance(facility_response, ResponseSuccess):
+                if facility_response.response_type == ResponseTypes.SUCCESS:
                     work_shift_json["facility_info"]=facility_response.value
                 else:
                     work_shift_json["facility_info"]=\
-                    "Facilityinformation could not be retrieved"
+                    "Facility information could not be retrieved"
                 enriched_shifts.append(work_shift_json)
             return Response(
                 json.dumps(enriched_shifts),

--- a/server/application/rest/work_shift.py
+++ b/server/application/rest/work_shift.py
@@ -14,7 +14,6 @@ from use_cases.get_facility_info import get_facility_info_use_case
 from serializers.work_shift import WorkShiftJsonEncoder
 from serializers.staffing import StaffingJsonEncoder
 from responses import ResponseTypes, ResponseSuccess
-from requests.work_shift_list import build_work_shift_list_request
 from application.rest.request_from_params import list_shift_request
 
 blueprint = Blueprint("work_shift", __name__)

--- a/server/tests/rest/test_work_shift.py
+++ b/server/tests/rest/test_work_shift.py
@@ -11,34 +11,41 @@ shifts_data = [
         'worker': 'volunteer@slu.edu',
         'shelter': 'existing-shelter-id',
         'start_time': 1701441800000,
-        'end_time': 1701452600000
+        'end_time': 1701452600000,
+        'facility_info': {'info': 'Some facility info for existing-shelter-id'}
     },
     {
         'code': 'f853578c-fc0f-4e65-81b8-566c5dffa35b',
         'worker': 'volunteer@slu.edu',
         'shelter': 'existing-shelter-id',
         'start_time': 1701442800000,
-        'end_time': 1701453600000
+        'end_time': 1701453600000,
+        'facility_info': {'info': 'Some facility info for existing-shelter-id'}
     }
 ]
 
 @mock.patch('application.app.work_shift.workshift_list_use_case')
-def test_list_work_shifts(mock_use_case):
-    mock_response = ResponseSuccess(shifts_data)
-    mock_use_case.return_value = mock_response
+@mock.patch('application.app.work_shift.get_facility_info_use_case')
+def test_list_work_shifts(mock_facility_info_use_case, mock_workshift_list_use_case):
+    # Mock the facility info use case to return successful facility information
+    mock_facility_response = ResponseSuccess({'info': 'Some facility info for existing-shelter-id'})
+    mock_facility_info_use_case.return_value = mock_facility_response
+
+    # Mock the work shift list use case to return the shifts data
+    mock_workshift_list_response = ResponseSuccess(shifts_data)
+    mock_workshift_list_use_case.return_value = mock_workshift_list_response
 
     app = create_app('testing')
     client = app.test_client()
-    headers = {
-        'Authorization': 'volunteer@slu.edu'
-    }
+    headers = {'Authorization': 'volunteer@slu.edu'}
     response = client.get('/shifts', headers=headers)
     data = json.loads(response.data)
 
+    # The data should now include facility_info
     assert data == shifts_data
     assert response.status_code == 200
-    mock_use_case.assert_called()
-
+    mock_workshift_list_use_case.assert_called()
+    mock_facility_info_use_case.assert_called_with('existing-shelter-id')
 
 @mock.patch('application.app.work_shift.workshift_add_multiple_use_case')
 def test_add_work_shifts(mock_use_case):

--- a/server/tests/rest/test_work_shift.py
+++ b/server/tests/rest/test_work_shift.py
@@ -26,9 +26,11 @@ shifts_data = [
 
 @mock.patch('application.app.work_shift.workshift_list_use_case')
 @mock.patch('application.app.work_shift.get_facility_info_use_case')
-def test_list_work_shifts(mock_facility_info_use_case, mock_workshift_list_use_case):
+def test_list_work_shifts(mock_facility_info_use_case,
+                          mock_workshift_list_use_case):
     # Mock the facility info use case to return successful facility information
-    mock_facility_response = ResponseSuccess({'info': 'Some facility info for existing-shelter-id'})
+    mock_facility_response = ResponseSuccess({
+        'info': 'Some facility info for existing-shelter-id'})
     mock_facility_info_use_case.return_value = mock_facility_response
 
     # Mock the work shift list use case to return the shifts data
@@ -116,7 +118,7 @@ def test_count_workers(mock_use_case):
         'Content-Type': 'application/json'
     }
     response = client.get(
-        '/counts/123?start_after=100&end_before=200', 
+        '/counts/123?start_after=100&end_before=200',
         headers=headers)
 
     print(response.data)

--- a/server/tests/use_cases/test_get_facility_info.py
+++ b/server/tests/use_cases/test_get_facility_info.py
@@ -1,0 +1,42 @@
+import json
+from unittest import TestCase, mock
+from urllib import request, error
+from unittest.mock import MagicMock
+from use_cases.get_facility_info import get_facility_info_use_case
+from responses import ResponseSuccess, ResponseFailure, ResponseTypes
+
+class TestGetFacilityInfoUseCase(TestCase):
+
+    @mock.patch('use_cases.get_facility_info.request.urlopen')
+    def test_get_facility_info_success(self, mock_urlopen):
+        facility_id = 'some-facility-id'
+        facility_info = {'name': 'Test name', 'city': 'Chicago'}
+        mock_http_response = MagicMock()
+        mock_http_response.__enter__.return_value = mock_http_response
+        mock_http_response.status = 200
+        mock_http_response.read.return_value = json.dumps(facility_info).encode('utf-8')
+        mock_urlopen.return_value = mock_http_response
+        response = get_facility_info_use_case(facility_id)
+        self.assertIsInstance(response, ResponseSuccess)
+
+    @mock.patch('use_cases.get_facility_info.request.urlopen')
+    def test_get_facility_info_system_error(self, mock_urlopen):
+        facility_id = 'some-facility-id'
+        mock_urlopen.side_effect = error.URLError('Mocked URLError')
+        response = get_facility_info_use_case(facility_id)
+        self.assertIsInstance(response, ResponseFailure)
+        self.assertEqual(response.value['type'], ResponseTypes.SYSTEM_ERROR) 
+
+    @mock.patch('use_cases.get_facility_info.request.urlopen')
+    def test_get_facility_info_failure(self, mock_urlopen):
+        facility_id = 'some-facility-id'
+        mock_http_response = mock.MagicMock()
+        mock_http_response.__enter__.return_value = mock_http_response
+        mock_http_response.status = 404
+        mock_http_response.read.return_value = b''
+        mock_urlopen.return_value = mock_http_response
+        response = get_facility_info_use_case(facility_id)
+        self.assertIsInstance(response, ResponseFailure)
+        self.assertEqual(response.response_type, ResponseTypes.NOT_FOUND)
+        self.assertEqual(response.value, {"type": ResponseTypes.NOT_FOUND,
+                                          "message": 'Facility info could not be retrieved'})

--- a/server/tests/use_cases/test_get_facility_info.py
+++ b/server/tests/use_cases/test_get_facility_info.py
@@ -1,12 +1,18 @@
+"""
+This module contains the test cases for get facility information.
+"""
 import json
 from unittest import TestCase, mock
-from urllib import request, error
 from unittest.mock import MagicMock
+from urllib import error
 from use_cases.get_facility_info import get_facility_info_use_case
 from responses import ResponseSuccess, ResponseFailure, ResponseTypes
 
-class TestGetFacilityInfoUseCase(TestCase):
 
+class TestGetFacilityInfoUseCase(TestCase):
+    """
+    Test cases for the get_facility_info use case.
+    """
     @mock.patch('use_cases.get_facility_info.request.urlopen')
     def test_get_facility_info_success(self, mock_urlopen):
         facility_id = 'some-facility-id'
@@ -14,7 +20,8 @@ class TestGetFacilityInfoUseCase(TestCase):
         mock_http_response = MagicMock()
         mock_http_response.__enter__.return_value = mock_http_response
         mock_http_response.status = 200
-        mock_http_response.read.return_value = json.dumps(facility_info).encode('utf-8')
+        mock_http_response.read.return_value = json.dumps(facility_info) \
+            .encode('utf-8')
         mock_urlopen.return_value = mock_http_response
         response = get_facility_info_use_case(facility_id)
         self.assertIsInstance(response, ResponseSuccess)
@@ -25,12 +32,12 @@ class TestGetFacilityInfoUseCase(TestCase):
         mock_urlopen.side_effect = error.URLError('Mocked URLError')
         response = get_facility_info_use_case(facility_id)
         self.assertIsInstance(response, ResponseFailure)
-        self.assertEqual(response.value['type'], ResponseTypes.SYSTEM_ERROR) 
+        self.assertEqual(response.value['type'], ResponseTypes.SYSTEM_ERROR)
 
     @mock.patch('use_cases.get_facility_info.request.urlopen')
     def test_get_facility_info_failure(self, mock_urlopen):
         facility_id = 'some-facility-id'
-        mock_http_response = mock.MagicMock()
+        mock_http_response = MagicMock()
         mock_http_response.__enter__.return_value = mock_http_response
         mock_http_response.status = 404
         mock_http_response.read.return_value = b''
@@ -38,5 +45,7 @@ class TestGetFacilityInfoUseCase(TestCase):
         response = get_facility_info_use_case(facility_id)
         self.assertIsInstance(response, ResponseFailure)
         self.assertEqual(response.response_type, ResponseTypes.NOT_FOUND)
-        self.assertEqual(response.value, {"type": ResponseTypes.NOT_FOUND,
-                                          "message": 'Facility info could not be retrieved'})
+        self.assertEqual(response.value, {
+            'type': ResponseTypes.NOT_FOUND,
+            'message': 'Facility info could not be retrieved'
+        })

--- a/server/use_cases/get_facility_info.py
+++ b/server/use_cases/get_facility_info.py
@@ -10,6 +10,7 @@ def get_facility_info_use_case(facility_id):
                 data = json.loads(response.read().decode())
                 return ResponseSuccess(data)
             else:
-                return ResponseFailure('Facility info could not be retrieved')
+                return ResponseFailure(ResponseTypes.NOT_FOUND, 'Facility info could not be retrieved')
     except error.URLError as e:
         return ResponseFailure(ResponseTypes.SYSTEM_ERROR, str(e))
+

--- a/server/use_cases/get_facility_info.py
+++ b/server/use_cases/get_facility_info.py
@@ -1,3 +1,6 @@
+"""
+This module contains the use case for get facility information.
+"""
 from urllib import request, error
 from responses import ResponseFailure, ResponseSuccess, ResponseTypes
 import json
@@ -10,7 +13,8 @@ def get_facility_info_use_case(facility_id):
                 data = json.loads(response.read().decode())
                 return ResponseSuccess(data)
             else:
-                return ResponseFailure(ResponseTypes.NOT_FOUND, 'Facility info could not be retrieved')
+                return ResponseFailure(ResponseTypes.NOT_FOUND,
+                                    "Facility info could not be retrieved")
     except error.URLError as e:
         return ResponseFailure(ResponseTypes.SYSTEM_ERROR, str(e))
 

--- a/server/use_cases/get_facility_info.py
+++ b/server/use_cases/get_facility_info.py
@@ -1,12 +1,15 @@
-import requests
-from responses import ResponseFailure, ResponseSuccess
+from urllib import request, error
+from responses import ResponseFailure, ResponseSuccess, ResponseTypes
+import json
 
 def get_facility_info_use_case(facility_id):
     try:
-        response = requests.get(f"https://api2-qa.gethelp.com/v2/facilities/{facility_id}")
-        if response.status_code == 200:
-            return ResponseSuccess(response.json())
-        else:
-            return ResponseFailure(response.json())
-    except requests.RequestException as e:
-        return ResponseFailure(str(e))
+        url = f"https://api2-qa.gethelp.com/v2/facilities/{facility_id}"
+        with request.urlopen(url) as response:
+            if response.status == 200:
+                data = json.loads(response.read().decode())
+                return ResponseSuccess(data)
+            else:
+                return ResponseFailure('Facility info could not be retrieved')
+    except error.URLError as e:
+        return ResponseFailure(ResponseTypes.SYSTEM_ERROR, str(e))

--- a/server/use_cases/get_facility_info.py
+++ b/server/use_cases/get_facility_info.py
@@ -1,0 +1,12 @@
+import requests
+from responses import ResponseFailure, ResponseSuccess
+
+def get_facility_info_use_case(facility_id):
+    try:
+        response = requests.get(f"https://api2-qa.gethelp.com/v2/facilities/{facility_id}")
+        if response.status_code == 200:
+            return ResponseSuccess(response.json())
+        else:
+            return ResponseFailure(response.json())
+    except requests.RequestException as e:
+        return ResponseFailure(str(e))


### PR DESCRIPTION
Fixes #32

**What was changed?**

Requests to the /shifts endpoint now return shift information along with facility_info, describing the facility in which the shift is scheduled.

**Why was it changed?**

This change will allow us to show details about the facility in which a volunteer is scheduled to work, such as location, phone number, web site, etc.

**How was it changed?**

A new feature was added under use_cases directory in the server code, which calls GetHelp API with a specific facility id, to retrieve that facility's details. Before responding to the /shifts request, each shift's facility id is used to get the facility information, through this new use case.
