### PR TITLE
Fix issue #48-Disallow selecting past times

### DIFF
--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -13,6 +13,19 @@ const IndividualShelter = (props) => {
     setHours(setMinutes(new Date(), 0), new Date().getHours() + 2)
   );
 
+    const filterPastStartTime = (time) => {
+      const currentDate = new Date();
+      const selectedDate = new Date(time);
+      return  currentDate.getTime() < selectedDate.getTime();
+      };
+        
+    const filterPastEndTime = (time) => {
+       const currentDate = new Date();
+       const selectedDate = new Date(time);
+       currentDate.setHours(currentDate.getHours() + 1);
+       return  currentDate.getTime() < selectedDate.getTime();
+       };
+    
   function addShift() {
     if (props.addShiftFunction) {
       let id = shelter.id;
@@ -61,18 +74,24 @@ const IndividualShelter = (props) => {
             <DatePicker
               className="date-picker"
               selected={startTime}
+              filterTime={filterPastStartTime}
               onChange={(date) => modifyStart(date)}
               showTimeSelect
               dateFormat="M/dd/yy h:mm aa"
+              minDate={new Date()}
+              showDisabledMonthNavigation
             />
             <br />
             <br />
             <label>End Time: </label>
             <DatePicker
               selected={endTime}
+              filterTime={filterPastEndTime}
               onChange={(date) => modifyEnd(date)}
               showTimeSelect
               dateFormat="M/dd/yy h:mm aa"
+              minDate={new Date()}
+              showDisabledMonthNavigation
             />
             <br />
             <br />


### PR DESCRIPTION
The issue I selected was the current system allowed users to schedule times in the past (issue no 48). Therefore the issue to be fixed was to disallow users from selecting times in the past. 

**What was changed?**
All changes were made in the IndividualShelter.js file found in _client\_app/src/Components/_.

**Why was it changed?**
The calendar allowed users to select dates and times that were in the past. Therefore, changes were made to ensure that users could not select dates/times from the past in the calendar. The main changes are summarized below.

1. **_Show Available Dates_** - Updated the calendar to only shows dates from the current month onwards and only dates from the current date onwards can be selected.
2. **_Show Available Times_** - Updated the calendar to only show available start and end times. Available start times begin from the next half hour, and available end times begin 1 hour after the available start time.

**How was it changed?**
The main changes made in  _IndividualShelter.js_ file are summarized below:

1. _**Show Available Dates**_ - In the file, changes were made to the return component Start Time and End Time DatePickers. Added minDate (line 81, 93) to set the current date as the minimum active date to be shown in the calendar. Added showDisabledMonthNavigtion (line 82, 94) to set the current month as the oldest month in the calendar but with days older than today disabled.

3.  **_Show Available Times_** - Added filterPastStartTime (line 16) and filterPastEndTime (line 22) to show only available times for the Start Time and End Time calendars. The filterPastStartTime shows available times starting in the next half hour while filterPastEndTime shows available end times starting 1 hour after the first available start time. Added lines 77 and 89 in the return component to run these components.4. 
![Fix issue 48](https://github.com/oss-slu/shelter_volunteers/assets/11279816/37201513-c0bc-4969-9481-fb807b793ac7)
