### PR TITLE
Make URL for GetHelp API configurable

### DIFF
--- a/client_app/src/Shelters.js
+++ b/client_app/src/Shelters.js
@@ -1,14 +1,16 @@
 import { useState, useEffect } from "react";
 import ShelterList from "./Components/ShelterList";
 import ConfirmationPage from "./Components/ConfirmationPage";
-import { SERVER } from "./config";
+import { GETHELP_API, SERVER } from "./config";
 import { Link } from "react-router-dom";
 import ShiftList from "./Components/ShiftList";
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCalendarDays,faArrowRight,faCircleXmark } from '@fortawesome/free-solid-svg-icons'
-import { useSpring, animated } from '@react-spring/web'
-
-
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faCalendarDays,
+  faArrowRight,
+  faCircleXmark,
+} from "@fortawesome/free-solid-svg-icons";
+import { useSpring, animated } from "@react-spring/web";
 
 const Shelters = (props) => {
   let defaultRadius = "5";
@@ -21,16 +23,15 @@ const Shelters = (props) => {
   const [isButtonDisabled, setButtonDisabled] = useState(true);
   const [selectedShifts, setSelectedShifts] = useState([]);
   const [showConfirmation, setShowConfirmation] = useState(false);
-  const [onMobileContinueclicked,setOnMobileContinueclicked]=useState(false);
-  const [shaking, setShaking] = useState(false)
+  const [onMobileContinueclicked, setOnMobileContinueclicked] = useState(false);
+  const [shaking, setShaking] = useState(false);
 
   const shakeAnimation = useSpring({
-    transform: shaking ? 'translateY(-20px)' : 'translateY(0px)'  
-  })
+    transform: shaking ? "translateY(-20px)" : "translateY(0px)",
+  });
 
-  let shelters_endpoint =
-    "https://api2-qa.gethelp.com/v2/facilities?page=0&pageSize=1000";
-  let volunteers_endpoint = "https://api2-qa.gethelp.com/volunteers/";
+  let shelters_endpoint = GETHELP_API + "v2/facilities?page=0&pageSize=1000";
+  let volunteers_endpoint = GETHELP_API + "volunteers";
 
   useEffect(() => {
     setLoading(true);
@@ -50,6 +51,7 @@ const Shelters = (props) => {
     })
       .then(async (response) => (await response.json())["content"])
       .then((shelters) => {
+        console.log(shelters);
         if (props.condensed) {
           shelters = shelters.slice(0, 3);
         }
@@ -77,10 +79,10 @@ const Shelters = (props) => {
     let id = event.target.id;
     let shift =
       id.split("-")[2] + "-" + id.split("-")[3] + "-" + id.split("-")[4];
-    
+
     const codes = selectedShifts.map((s) => s.code);
     if (codes.includes(shift)) {
-      let index = selectedShifts.findIndex((s) => s.code === shift)
+      let index = selectedShifts.findIndex((s) => s.code === shift);
       if (index !== -1) {
         const newSelected = [...selectedShifts];
         newSelected.splice(index, 1);
@@ -100,8 +102,8 @@ const Shelters = (props) => {
   }
 
   function manageShifts(shift) {
-    setShaking(true)
-    setTimeout(() => setShaking(false), 200)
+    setShaking(true);
+    setTimeout(() => setShaking(false), 200);
     setSelectedShifts([...selectedShifts, shift]);
     setButtonDisabled(selectedShifts.length === 0);
   }
@@ -121,13 +123,13 @@ const Shelters = (props) => {
       .catch((error) => console.log(error));
   }
 
-  function onMobileContinueClick(){
-    if (selectedShifts.length<1) {
-      return
+  function onMobileContinueClick() {
+    if (selectedShifts.length < 1) {
+      return;
     }
     setOnMobileContinueclicked(true);
   }
-  function handleCurrentSelectionClose(){
+  function handleCurrentSelectionClose() {
     setOnMobileContinueclicked(false);
   }
 
@@ -184,11 +186,26 @@ const Shelters = (props) => {
                     isSignupPage={true}
                   />
                 </div>
-                <div className={onMobileContinueclicked?"column column-2 active":"column column-2"}>
-                  <div className={onMobileContinueclicked?"current-selection active":"current-selection"}>
+                <div
+                  className={
+                    onMobileContinueclicked
+                      ? "column column-2 active"
+                      : "column column-2"
+                  }
+                >
+                  <div
+                    className={
+                      onMobileContinueclicked
+                        ? "current-selection active"
+                        : "current-selection"
+                    }
+                  >
                     <h2>Current Selection</h2>
-                    {onMobileContinueclicked&&(
-                      <div className="close-btn" onClick={handleCurrentSelectionClose}>
+                    {onMobileContinueclicked && (
+                      <div
+                        className="close-btn"
+                        onClick={handleCurrentSelectionClose}
+                      >
                         <FontAwesomeIcon icon={faCircleXmark} size="2x" />
                       </div>
                     )}
@@ -211,20 +228,38 @@ const Shelters = (props) => {
                     </div>
                   </div>
                 </div>
-                {!onMobileContinueclicked&&(<div className="continue-bottom-row">
-                  <animated.div className="cart" onClick={onMobileContinueClick} style={shakeAnimation}>
-                    <div className="circle">
-                      <FontAwesomeIcon icon={faCalendarDays} size="2x"/>
-                    </div>
-                    <div className="count-bubble">
+                {!onMobileContinueclicked && (
+                  <div className="continue-bottom-row">
+                    <animated.div
+                      className="cart"
+                      onClick={onMobileContinueClick}
+                      style={shakeAnimation}
+                    >
+                      <div className="circle">
+                        <FontAwesomeIcon icon={faCalendarDays} size="2x" />
+                      </div>
+                      <div className="count-bubble">
                         {selectedShifts.length}
-                    </div>
-                  </animated.div>
-                  <button className={selectedShifts.length>0?"cont-btn":"cont-btn disabled"} onClick={onMobileContinueClick}>
-                    Continue 
-                    {selectedShifts.length>0 && (<FontAwesomeIcon icon={faArrowRight} style={{"marginLeft":"1em"}}/>)}
-                  </button>
-                </div>)}
+                      </div>
+                    </animated.div>
+                    <button
+                      className={
+                        selectedShifts.length > 0
+                          ? "cont-btn"
+                          : "cont-btn disabled"
+                      }
+                      onClick={onMobileContinueClick}
+                    >
+                      Continue
+                      {selectedShifts.length > 0 && (
+                        <FontAwesomeIcon
+                          icon={faArrowRight}
+                          style={{ marginLeft: "1em" }}
+                        />
+                      )}
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/client_app/src/Shelters.js
+++ b/client_app/src/Shelters.js
@@ -51,7 +51,6 @@ const Shelters = (props) => {
     })
       .then(async (response) => (await response.json())["content"])
       .then((shelters) => {
-        console.log(shelters);
         if (props.condensed) {
           shelters = shelters.slice(0, 3);
         }

--- a/client_app/src/config.js
+++ b/client_app/src/config.js
@@ -1,1 +1,3 @@
-export const SERVER = process.env.REACT_APP_SERVER_URL || 'http://127.0.0.1:5000'
+export const SERVER =
+  process.env.REACT_APP_SERVER_URL || "http://127.0.0.1:5000";
+export const GETHELP_API = "https://api2-qa.gethelp.com/";

--- a/server/application/config.py
+++ b/server/application/config.py
@@ -16,7 +16,7 @@ class ProductionConfig(Config):
 
 class DevelopmentConfig(Config):
     """Development configuration"""
-
+    os.environ["GETHELP_API"] = "https://api2-qa.gethelp.com/"
 
 class TestingConfig(Config):
     """Testing configuration"""

--- a/server/application/config.py
+++ b/server/application/config.py
@@ -20,5 +20,5 @@ class DevelopmentConfig(Config):
 
 class TestingConfig(Config):
     """Testing configuration"""
-
+    os.environ["GETHELP_API"] = "https://api2-qa.gethelp.com/"
     TESTING = True

--- a/server/run_dev_server.sh
+++ b/server/run_dev_server.sh
@@ -1,2 +1,3 @@
 export FLASK_CONFIG="development"
+export GETHELP_API="https://api2-qa.gethelp.com/"
 flask run

--- a/server/run_dev_server.sh
+++ b/server/run_dev_server.sh
@@ -1,3 +1,2 @@
 export FLASK_CONFIG="development"
-export GETHELP_API="https://api2-qa.gethelp.com/"
 flask run

--- a/server/use_cases/get_facility_info.py
+++ b/server/use_cases/get_facility_info.py
@@ -1,13 +1,16 @@
 """
 This module contains the use case for get facility information.
 """
+import os
+
 from urllib import request, error
 from responses import ResponseFailure, ResponseSuccess, ResponseTypes
 import json
 
 def get_facility_info_use_case(facility_id):
     try:
-        url = f"https://api2-qa.gethelp.com/v2/facilities/{facility_id}"
+        GETHELP_API = os.environ["GETHELP_API"]
+        url = GETHELP_API + f"v2/facilities/{facility_id}"
         with request.urlopen(url) as response:
             if response.status == 200:
                 data = json.loads(response.read().decode())

--- a/server/use_cases/get_facility_info.py
+++ b/server/use_cases/get_facility_info.py
@@ -9,8 +9,8 @@ import json
 
 def get_facility_info_use_case(facility_id):
     try:
-        GETHELP_API = os.environ["GETHELP_API"]
-        url = GETHELP_API + f"v2/facilities/{facility_id}"
+        gethelp_api = os.environ["GETHELP_API"]
+        url = gethelp_api + f"v2/facilities/{facility_id}"
         with request.urlopen(url) as response:
             if response.status == 200:
                 data = json.loads(response.read().decode())


### PR DESCRIPTION
Fixes #42

**What was changed?**

I configured both the client and the server so that the URL for the GetHelp API is not completely hardcoded

**Why was it changed?**

This was changed because the URL will eventually need to be different when deploying to production

**How was it changed?**

On the client side, I added a variable to the config file that stores the URL and can be imported into whichever page wants to use it. On the server side, I added an environment variable to the testing and development config that is eventually used in some of the use cases.