### PR TITLE
Send the correct authentication header with a cancel shift request

### DIFF
--- a/client_app/src/Shifts.js
+++ b/client_app/src/Shifts.js
@@ -22,10 +22,7 @@ function Shifts(request_endpoint) {
   const handleCancelShift = (shiftCode) => {
     fetch(`${SERVER}/shifts/${shiftCode}`, {
       method: "DELETE",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "volunteer@slu.edu",
-      },
+      headers: header,
     })
       .then((response) => {
         if (response.ok) {


### PR DESCRIPTION
Small fix related to authentication on "cancel shift" request

**What was changed?**

The ability to cancel a shift was added before authentication was added (while authentication was being worked on). When we merged the authentication code into the main branch, the "cancel shift" feature was still using the old mock authentication. This resulted in a failure to cancel shifts. 

**How was it changed?**

I updated the header of the cancel message to include the correct authentication token.

