### PR TITLE
Issue 43 shelter info

### DIFF
--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -145,6 +145,10 @@ const IndividualShelter = (props) => {
               <p>
                 {shelter.city}, {shelter.state} {shelter.zipCode}
               </p>
+              <p>
+                {shelter.phone}
+              </p>
+              <a href={shelter.website}>{shelter.website}</a>
               <p>{+shelter.distance.toFixed(2)} miles away</p>
             </div>
             <div className="column2">

--- a/client_app/src/Components/ShiftList.js
+++ b/client_app/src/Components/ShiftList.js
@@ -67,7 +67,10 @@ const ShiftList = (props) => {
               )}
               {props.fromShelter !== true && (
                 <div>
-                  <h2>{shift.shelter}</h2>
+                  <h2>{shift.facility_info.name}</h2>
+                  <p>{shift.facility_info.city}, {shift.facility_info.state}, {shift.facility_info.zipCode}</p>
+                  <p>{shift.facility_info.phone}</p>
+                  <p><a href={shift.facility_info.website}>{shift.facility_info.website}</a></p>
                 </div>
               )}
               <p>

--- a/client_app/src/index.css
+++ b/client_app/src/index.css
@@ -189,6 +189,7 @@ p {
   flex-direction: column; 
   align-items: center; 
   background-color: #bde3c8;
+  text-align: center;
 }
 
 .cancelbtn {


### PR DESCRIPTION
Fixes #43 

**What was changed?**

Client side changes: show facility name, city, state, zip code, phone number, and web-site (if available), when displaying facility information in either sign-up for shifts page, or upcoming/previous shifts.

**Why was it changed?**

Users will need to have information about where the facility is located and how to contact the facility

**How was it changed?**
Upcoming shifts:
<img width="1472" alt="Screen Shot 2023-12-03 at 2 44 48 PM" src="https://github.com/oss-slu/shelter_volunteers/assets/42073871/251ab2bd-dd54-4f9e-b4ce-1ee13aa6afec">

Previous shifts (the data returned with previous shifts did not always have website info)
<img width="1470" alt="Screen Shot 2023-12-03 at 2 45 15 PM" src="https://github.com/oss-slu/shelter_volunteers/assets/42073871/212b403f-8a18-492c-b498-cc31c21b57d4">

Dashboard's upcoming shifts:
<img width="1475" alt="Screen Shot 2023-12-03 at 2 46 07 PM" src="https://github.com/oss-slu/shelter_volunteers/assets/42073871/e89c5b95-9869-4642-948b-d2bb4fdeb1f4">

Sign up for shifts:
<img width="1481" alt="Screen Shot 2023-12-03 at 2 48 40 PM" src="https://github.com/oss-slu/shelter_volunteers/assets/42073871/1aab65d0-c7b3-43c5-8a93-27a71103252b">
