### PR TITLE
Unique key prop warning for shelterList issue(#65) fixes 

### DIFF
--- a/client_app/src/Components/ShelterList.js
+++ b/client_app/src/Components/ShelterList.js
@@ -22,7 +22,7 @@ const ShelterList = (props) => {
                 props.loadingFunction(false);
               }
               return (
-                <div>
+                <div key={shelter.id}>
                   <IndividualShelter
                     shelter={shelter}
                     isSignupPage={props.isSignupPage}


### PR DESCRIPTION
Fixes #65

**What was changed?**

I changed the list of data (ShelterList) that is displayed on the homepage of the website. 

**Why was it changed?**

There was an issue about how each child should have a unique key. JSX auto-defaults to using index, but that can cause unexpected behavior when a list is not static and a longer rendering time. This issue appeared on the console when on the home page, as it was from the file that displayed the list of shelters (ShelterList.js)

**How was it changed?**

I added that when the shelter would get added if it met the condition in the if loop it would assign a key to the element using the unique shelter.id variable. 

<img width="555" alt="Screenshot 2024-02-02 at 12 31 01 AM" src="https://github.com/oss-slu/shelter_volunteers/assets/123024485/17247a2c-1109-40c5-bea7-9d2029e166fb">

Added line 25 and now the error is gone.
