### PR TITLE
"Current Volunteer Counts" div should be displayed on button click for each shelter fixed (issue 73)

### DIFF
--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -35,7 +35,10 @@ const IndividualShelter = (props) => {
     return currentDate.getTime() < selectedDate.getTime();
   };
   const ExampleCustomInput = forwardRef(({ value, onClick }, ref) => (
-    <button className="example-custom-input" onClick={() => setHidden(!hidden)} ref={ref}>
+    <button className="example-custom-input" onClick={(event) => {
+      onClick(event); 
+      setHidden(!hidden);
+    }} ref={ref}>
       {value}
     </button>
   ));
@@ -151,6 +154,7 @@ const IndividualShelter = (props) => {
               </p>
               <a href={shelter.website}>{shelter.website}</a>
               <p>{+shelter.distance.toFixed(2)} miles away</p>
+              
               <button onClick={() => setHidden(!hidden)}>
                 {hidden ? "View Current Volunteer Counts" : "Hide Current Volunteer Counts"}
               </button>
@@ -202,21 +206,23 @@ const IndividualShelter = (props) => {
             </div>
           </div>
 
-          <div className="signupcard shift-graph text-center" style={{ display: hidden ? "none" : "block" }}>
-            <h3>Current Volunteer Counts</h3>
-            <div className="shift-count">
-              {!loading && shiftCounts && shiftCounts.length > 0 && (
-                <div>{<GraphComponent shifts={shiftCounts} />}</div>
-              )}
-              {!loading && shiftCounts && shiftCounts.length === 0 && (
-                <p>
-                  No volunteers are currently signed up during your selected
-                  time range.
-                </p>
-              )}
-              {loading && <p>Loading...</p>}
+          {!hidden && (
+            <div className="signupcard shift-graph text-center">
+              <h3>Current Volunteer Counts</h3>
+              <div className="shift-count">
+                {!loading && shiftCounts && shiftCounts.length > 0 && (
+                  <div>{<GraphComponent shifts={shiftCounts} />}</div>
+                )}
+                {!loading && shiftCounts && shiftCounts.length === 0 && (
+                  <p>
+                    No volunteers are currently signed up during your selected
+                    time range.
+                  </p>
+                )}
+                {loading && <p>Loading...</p>}
+              </div>
             </div>
-          </div>
+          )}
         </div>
       )}
       {!props.isSignupPage && (

--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -9,6 +9,7 @@ import { SERVER } from "../config";
 import GraphComponent from "./GraphComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCirclePlus } from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
 
 const IndividualShelter = (props) => {
   let shelter = props.shelter;
@@ -37,7 +38,7 @@ const IndividualShelter = (props) => {
   const ExampleCustomInput = forwardRef(({ value, onClick }, ref) => (
     <button className="example-custom-input" onClick={(event) => {
       onClick(event); 
-      setHidden(!hidden);
+      setHidden(false);
     }} ref={ref}>
       {value}
     </button>
@@ -155,8 +156,9 @@ const IndividualShelter = (props) => {
               <a href={shelter.website}>{shelter.website}</a>
               <p>{+shelter.distance.toFixed(2)} miles away</p>
               
-              <button onClick={() => setHidden(!hidden)}>
-                {hidden ? "View Current Volunteer Counts" : "Hide Current Volunteer Counts"}
+              <button className="current-count" onClick={() => setHidden(!hidden)}>
+                {hidden ? "View Current Volunteer Counts  " : "Hide Current Volunteer Counts  "}
+                <FontAwesomeIcon icon={hidden ? faChevronDown : faChevronUp} size="lg"/>
               </button>
             </div>
             <div className="column2">

--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -20,6 +20,7 @@ const IndividualShelter = (props) => {
   );
   const [shiftCounts, setShiftCounts] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [hidden, setHidden] = useState(true);
 
   const filterPastStartTime = (time) => {
     const currentDate = new Date();
@@ -34,7 +35,7 @@ const IndividualShelter = (props) => {
     return currentDate.getTime() < selectedDate.getTime();
   };
   const ExampleCustomInput = forwardRef(({ value, onClick }, ref) => (
-    <button className="example-custom-input" onClick={onClick} ref={ref}>
+    <button className="example-custom-input" onClick={() => setHidden(!hidden)} ref={ref}>
       {value}
     </button>
   ));
@@ -150,6 +151,9 @@ const IndividualShelter = (props) => {
               </p>
               <a href={shelter.website}>{shelter.website}</a>
               <p>{+shelter.distance.toFixed(2)} miles away</p>
+              <button onClick={() => setHidden(!hidden)}>
+                {hidden ? "View Current Volunteer Counts" : "Hide Current Volunteer Counts"}
+              </button>
             </div>
             <div className="column2">
               <div className="dates">
@@ -198,7 +202,7 @@ const IndividualShelter = (props) => {
             </div>
           </div>
 
-          <div className="signupcard shift-graph text-center">
+          <div className="signupcard shift-graph text-center" style={{ display: hidden ? "none" : "block" }}>
             <h3>Current Volunteer Counts</h3>
             <div className="shift-count">
               {!loading && shiftCounts && shiftCounts.length > 0 && (

--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -21,7 +21,7 @@ const IndividualShelter = (props) => {
   );
   const [shiftCounts, setShiftCounts] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [hidden, setHidden] = useState(true);
+  const [volunteerCountsHidden, setVolunteerCountsHidden] = useState(true);
 
   const filterPastStartTime = (time) => {
     const currentDate = new Date();
@@ -38,7 +38,7 @@ const IndividualShelter = (props) => {
   const ExampleCustomInput = forwardRef(({ value, onClick }, ref) => (
     <button className="example-custom-input" onClick={(event) => {
       onClick(event); 
-      setHidden(false);
+      setVolunteerCountsHidden(false);
     }} ref={ref}>
       {value}
     </button>
@@ -156,9 +156,9 @@ const IndividualShelter = (props) => {
               <a href={shelter.website}>{shelter.website}</a>
               <p>{+shelter.distance.toFixed(2)} miles away</p>
               
-              <button className="current-count" onClick={() => setHidden(!hidden)}>
-                {hidden ? "View Current Volunteer Counts  " : "Hide Current Volunteer Counts  "}
-                <FontAwesomeIcon icon={hidden ? faChevronDown : faChevronUp} size="lg"/>
+              <button className="current-volunteer-count" onClick={() => setVolunteerCountsHidden(!volunteerCountsHidden)}>
+                {volunteerCountsHidden ? "View Current Volunteer Counts  " : "Hide Current Volunteer Counts  "}
+                <FontAwesomeIcon icon={volunteerCountsHidden ? faChevronDown : faChevronUp} size="lg"/>
               </button>
             </div>
             <div className="column2">
@@ -208,7 +208,7 @@ const IndividualShelter = (props) => {
             </div>
           </div>
 
-          {!hidden && (
+          {!volunteerCountsHidden && (
             <div className="signupcard shift-graph text-center">
               <h3>Current Volunteer Counts</h3>
               <div className="shift-count">

--- a/client_app/src/index.css
+++ b/client_app/src/index.css
@@ -305,7 +305,7 @@ button {
   cursor: pointer ;
 }
 
-.current-count {
+.current-volunteer-count {
   background-color: #ecececfc;
   border: none;
   outline: none;

--- a/client_app/src/index.css
+++ b/client_app/src/index.css
@@ -305,6 +305,16 @@ button {
   cursor: pointer ;
 }
 
+.current-count {
+  background-color: #ecececfc;
+  border: none;
+  outline: none;
+  color: #0066b2;
+  padding: 0.1em;
+  font-size: 16px;
+  text-decoration: underline;
+}
+
 @media screen and (max-width: 960px) {
   .volunteer-dashboard {
     display: block;


### PR DESCRIPTION
Fixes #73 

**What was changed?**

I changed the Volunteering Opportunities page by adding the "View Current Volunteer Counts" button for each shelter. When the button is clicked, the "Current Volunteer Counts" div will be displayed. The button name is also changed to "Hide Current Volunteer Counts" and when it is clicked, the "Current Volunteer Counts" div is hidden. The "Current Volunteer Counts" div is also displayed when clicking on the "Start Time date picker" and "End Time date picker".

**Why was it changed?**

It was changed to facilitate ease of use and reduce the number of API calls.

**How was it changed?**

I initialized a state variable "hidden" using useState hook and used that variable to determine when to render "the Current Volunteer Counts div". The button element has an onClick event handler, and when clicked, it calls the arrow function toggling the value of hidden. 

**Screenshots that show the changes (if applicable):**

<img width="835" alt="Screenshot 2024-02-23 at 1 31 28 PM" src="https://github.com/oss-slu/shelter_volunteers/assets/65869614/b34516be-6ae1-4195-b941-f999671890da">
<img width="830" alt="Screenshot 2024-02-23 at 1 31 37 PM" src="https://github.com/oss-slu/shelter_volunteers/assets/65869614/2128c5fb-a1ef-48af-aecd-b52fbc2982d9">



