### PR TITLE
Make the API call to display the details in "Current Volunteer Counts" div on button click (#74) fixed

### DIFF
--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -21,7 +21,7 @@ const IndividualShelter = (props) => {
   );
   const [shiftCounts, setShiftCounts] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [volunteerCountsHidden, setVolunteerCountsHidden] = useState(true);
+
 
   const filterPastStartTime = (time) => {
     const currentDate = new Date();
@@ -38,11 +38,12 @@ const IndividualShelter = (props) => {
   const ExampleCustomInput = forwardRef(({ value, onClick }, ref) => (
     <button className="example-custom-input" onClick={(event) => {
       onClick(event); 
-      setVolunteerCountsHidden(false);
+      props.setVolunteerCountsHidden(false);
     }} ref={ref}>
       {value}
     </button>
   ));
+
 
   function addShift() {
     if (props.addShiftFunction) {
@@ -84,7 +85,7 @@ const IndividualShelter = (props) => {
       setSeconds(setMinutes(setHours(startTime, 23), 59), 59),
       999
     );
-    if (shelter) {
+    if (!props.volunteerCountsHidden) {
       setLoading(true);
       let request_endpoint =
         SERVER +
@@ -138,7 +139,7 @@ const IndividualShelter = (props) => {
         })
         .catch((error) => console.log(error));
     }
-  }, [startTime, shelter]);
+  }, [startTime, props.volunteerCountsHidden, shelter.id]);
 
   return (
     <div>
@@ -156,9 +157,9 @@ const IndividualShelter = (props) => {
               <a href={shelter.website}>{shelter.website}</a>
               <p>{+shelter.distance.toFixed(2)} miles away</p>
               
-              <button className="current-volunteer-count" onClick={() => setVolunteerCountsHidden(!volunteerCountsHidden)}>
-                {volunteerCountsHidden ? "View Current Volunteer Counts  " : "Hide Current Volunteer Counts  "}
-                <FontAwesomeIcon icon={volunteerCountsHidden ? faChevronDown : faChevronUp} size="lg"/>
+              <button className="current-volunteer-count" onClick={() => props.setVolunteerCountsHidden(!props.volunteerCountsHidden)}>
+                {props.volunteerCountsHidden ? "View Current Volunteer Counts  " : "Hide Current Volunteer Counts  "}
+                <FontAwesomeIcon icon={props.volunteerCountsHidden ? faChevronDown : faChevronUp} size="lg"/>
               </button>
             </div>
             <div className="column2">
@@ -208,7 +209,7 @@ const IndividualShelter = (props) => {
             </div>
           </div>
 
-          {!volunteerCountsHidden && (
+          {!props.volunteerCountsHidden && (
             <div className="signupcard shift-graph text-center">
               <h3>Current Volunteer Counts</h3>
               <div className="shift-count">

--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -21,6 +21,7 @@ const IndividualShelter = (props) => {
   );
   const [shiftCounts, setShiftCounts] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [volunteerCountsHidden, setVolunteerCountsHidden] = useState(true);
 
 
   const filterPastStartTime = (time) => {
@@ -38,7 +39,7 @@ const IndividualShelter = (props) => {
   const ExampleCustomInput = forwardRef(({ value, onClick }, ref) => (
     <button className="example-custom-input" onClick={(event) => {
       onClick(event); 
-      props.setVolunteerCountsHidden(false);
+      setVolunteerCountsHidden(false);
     }} ref={ref}>
       {value}
     </button>
@@ -85,7 +86,7 @@ const IndividualShelter = (props) => {
       setSeconds(setMinutes(setHours(startTime, 23), 59), 59),
       999
     );
-    if (!props.volunteerCountsHidden) {
+    if (!volunteerCountsHidden && shelter) {
       setLoading(true);
       let request_endpoint =
         SERVER +
@@ -139,7 +140,7 @@ const IndividualShelter = (props) => {
         })
         .catch((error) => console.log(error));
     }
-  }, [startTime, props.volunteerCountsHidden, shelter.id]);
+  }, [startTime, volunteerCountsHidden, shelter]);
 
   return (
     <div>
@@ -157,9 +158,9 @@ const IndividualShelter = (props) => {
               <a href={shelter.website}>{shelter.website}</a>
               <p>{+shelter.distance.toFixed(2)} miles away</p>
               
-              <button className="current-volunteer-count" onClick={() => props.setVolunteerCountsHidden(!props.volunteerCountsHidden)}>
-                {props.volunteerCountsHidden ? "View Current Volunteer Counts  " : "Hide Current Volunteer Counts  "}
-                <FontAwesomeIcon icon={props.volunteerCountsHidden ? faChevronDown : faChevronUp} size="lg"/>
+              <button className="current-volunteer-count" onClick={() => setVolunteerCountsHidden(!volunteerCountsHidden)}>
+                {volunteerCountsHidden ? "View Current Volunteer Counts  " : "Hide Current Volunteer Counts  "}
+                <FontAwesomeIcon icon={volunteerCountsHidden ? faChevronDown : faChevronUp} size="lg"/>
               </button>
             </div>
             <div className="column2">
@@ -209,7 +210,7 @@ const IndividualShelter = (props) => {
             </div>
           </div>
 
-          {!props.volunteerCountsHidden && (
+          {!volunteerCountsHidden && (
             <div className="signupcard shift-graph text-center">
               <h3>Current Volunteer Counts</h3>
               <div className="shift-count">

--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -23,7 +23,6 @@ const IndividualShelter = (props) => {
   const [loading, setLoading] = useState(false);
   const [volunteerCountsHidden, setVolunteerCountsHidden] = useState(true);
 
-
   const filterPastStartTime = (time) => {
     const currentDate = new Date();
     const selectedDate = new Date(time);
@@ -36,6 +35,7 @@ const IndividualShelter = (props) => {
     currentDate.setHours(currentDate.getHours() + 1);
     return currentDate.getTime() < selectedDate.getTime();
   };
+  
   const ExampleCustomInput = forwardRef(({ value, onClick }, ref) => (
     <button className="example-custom-input" onClick={(event) => {
       onClick(event); 
@@ -44,7 +44,6 @@ const IndividualShelter = (props) => {
       {value}
     </button>
   ));
-
 
   function addShift() {
     if (props.addShiftFunction) {
@@ -156,8 +155,7 @@ const IndividualShelter = (props) => {
                 {shelter.phone}
               </p>
               <a href={shelter.website}>{shelter.website}</a>
-              <p>{+shelter.distance.toFixed(2)} miles away</p>
-              
+              <p>{+shelter.distance.toFixed(2)} miles away</p>  
               <button className="current-volunteer-count" onClick={() => setVolunteerCountsHidden(!volunteerCountsHidden)}>
                 {volunteerCountsHidden ? "View Current Volunteer Counts  " : "Hide Current Volunteer Counts  "}
                 <FontAwesomeIcon icon={volunteerCountsHidden ? faChevronDown : faChevronUp} size="lg"/>

--- a/client_app/src/Components/ShelterList.js
+++ b/client_app/src/Components/ShelterList.js
@@ -1,7 +1,9 @@
 import IndividualShelter from "./IndividualShelter";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 
 const ShelterList = (props) => {
+
+  const [volunteerCountsHidden, setVolunteerCountsHidden] = useState(true);
   
     useEffect(() => {
       if (props.loadingFunction) {
@@ -30,6 +32,8 @@ const ShelterList = (props) => {
                     shelter={shelter}
                     isSignupPage={props.isSignupPage}
                     addShiftFunction={addShift}
+                    volunteerCountsHidden={volunteerCountsHidden}
+                    setVolunteerCountsHidden={setVolunteerCountsHidden}
                   />
                 </div>
               );

--- a/client_app/src/Components/ShelterList.js
+++ b/client_app/src/Components/ShelterList.js
@@ -1,9 +1,8 @@
 import IndividualShelter from "./IndividualShelter";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 
 const ShelterList = (props) => {
 
-  const [volunteerCountsHidden, setVolunteerCountsHidden] = useState(true);
   
     useEffect(() => {
       if (props.loadingFunction) {
@@ -32,8 +31,6 @@ const ShelterList = (props) => {
                     shelter={shelter}
                     isSignupPage={props.isSignupPage}
                     addShiftFunction={addShift}
-                    volunteerCountsHidden={volunteerCountsHidden}
-                    setVolunteerCountsHidden={setVolunteerCountsHidden}
                   />
                 </div>
               );

--- a/client_app/src/Shelters.js
+++ b/client_app/src/Shelters.js
@@ -31,7 +31,6 @@ const Shelters = (props) => {
   const [originalData, setOriginalData] = useState([]);
   const [noSearchDataAvailable, setNoSearchDataAvailable] = useState(false);
 
-
   const shakeAnimation = useSpring({
     transform: shaking ? "translateY(-20px)" : "translateY(0px)",
   });


### PR DESCRIPTION
Fixes #issue_74

**What was changed?**

I changed the the Volunteering Opportunities page. When a user clicks on the "View Current Volunteer Counts" button, the "Start time date" picker or the "End time date" picker in each shelter, an API call is made to get the shift details of that shelter only. 
 
**Why was it changed?**

It was changed to reduce a huge number of API call that could slow down the network. 

**How was it changed?**

I changed the condition of the if statement inside the useEffect hook to make API calls only when the state of the volunteerCountsHidden and shelter is changed.

**Screenshots that show the changes (if applicable):**
<img width="1426" alt="ViewCVCisclicked" src="https://github.com/oss-slu/shelter_volunteers/assets/65869614/2aa6bec3-5fc5-4189-bb55-6d5db946ba89">
                                                      The "View Current Volunteer Counts" button is clicked.
<img width="1433" alt="STPisclicked" src="https://github.com/oss-slu/shelter_volunteers/assets/65869614/d01ae388-d26f-4d7c-9dda-8b2b44349a93">
                                                                      The "Start time date" picker is clicked.
<img width="1420" alt="ETPisclicked" src="https://github.com/oss-slu/shelter_volunteers/assets/65869614/34303975-8432-4c8f-8fde-946958ca7c13">
                                                                       The "End time date" picker is clicked.
<img width="1412" alt="STPischanged" src="https://github.com/oss-slu/shelter_volunteers/assets/65869614/b5ff8b28-fae6-4cc7-94c8-d3df54b4e76b">
                                                                          The "Start time picker" is updated.

