### PR TITLE
Bug: validateDOMNesting(...): <tr> cannot appear as a child of <table> showed in the console fixed.

### DIFF
--- a/client_app/src/Components/ShiftList.js
+++ b/client_app/src/Components/ShiftList.js
@@ -36,17 +36,19 @@ const ShiftList = (props) => {
             {props.currentSelectionSection === true && (<div className= "currentselection"
               key={shift.code}>
                 <table>
-                  <tr>
-                    <td><p>{shift.shelter}</p></td>
-                    <td><p>
-                      {formattedStartTime} to {formattedEndTime}</p></td>
-                    <td>
-                      <button 
-                        className="closebtn"
-                        id={"shift-closebtn-" + shift.code}
-                        onClick={onCloseBtnClick}
-                        >X</button></td>
-                  </tr>
+                  <tbody>
+                    <tr>
+                      <td><p>{shift.shelter}</p></td>
+                      <td><p>
+                        {formattedStartTime} to {formattedEndTime}</p></td>
+                      <td>
+                        <button 
+                          className="closebtn"
+                          id={"shift-closebtn-" + shift.code}
+                          onClick={onCloseBtnClick}
+                          >X</button></td>
+                    </tr>
+                  </tbody>
                 </table>
 
             </div>)}


### PR DESCRIPTION
Fixes validateDOMNesting(...): <tr> cannot appear as a child of <table>

**What was changed?**

Small addition of a tag to resolve the error, no functionality has changed. 

**Why was it changed?**

It can cause weird bugs and we shouldn't have console errors.

**How was it changed?**

The specific problem was on ShiftList.js. I simply added <tbody> after the <table> tags as proper nesting. 

**Screenshots that show the changes (if applicable):**

Error is no longer present in the console. 
Before: 
<img width="1314" alt="Screenshot 2024-03-20 at 2 58 43 PM" src="https://github.com/oss-slu/shelter_volunteers/assets/123024485/bd0fd6ba-9a30-4091-b9a6-c2827dcd557d">

After:
<img width="1308" alt="Screenshot 2024-03-20 at 2 59 27 PM" src="https://github.com/oss-slu/shelter_volunteers/assets/123024485/c1a12ba3-2e02-4177-a877-6af78542e2b7">



