### PR TITLE
Bug: inconsistent timestamps fixed (#62)

### DIFF
--- a/client_app/src/Components/IndividualShelter.js
+++ b/client_app/src/Components/IndividualShelter.js
@@ -14,10 +14,10 @@ import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
 const IndividualShelter = (props) => {
   let shelter = props.shelter;
   const [startTime, setStartDate] = useState(
-    setHours(setMinutes(new Date(), 0), new Date().getHours() + 1)
+    setHours(setMinutes(setSeconds(setMilliseconds(new Date (), 0), 0), 0), new Date().getHours() + 1)
   );
   const [endTime, setEndDate] = useState(
-    setHours(setMinutes(new Date(), 0), new Date().getHours() + 2)
+    setHours(setMinutes(setSeconds(setMilliseconds(new Date (), 0), 0), 0), new Date().getHours() + 2)
   );
   const [shiftCounts, setShiftCounts] = useState([]);
   const [loading, setLoading] = useState(false);

--- a/server/tests/use_cases/test_add_workshifts.py
+++ b/server/tests/use_cases/test_add_workshifts.py
@@ -124,6 +124,6 @@ def test_workshift_add_multiple_use_case_timestamps(domain_work_shifts):
     user_id = domain_work_shifts[2].worker
     responses = repo.get_shifts_for_user(user_id)
     assert len(responses) == 2
-    assert responses[0]["end_time"] == responses[1]["start_time"]
+    assert responses[0].end_time == responses[1].start_time
 
 # pylint: enable=redefined-outer-name

--- a/server/tests/use_cases/test_add_workshifts.py
+++ b/server/tests/use_cases/test_add_workshifts.py
@@ -110,6 +110,7 @@ def test_workshift_add_multiple_use_case_no_overlap():
 
 def test_workshift_add_multiple_use_case_timestamps(domain_work_shifts):
     repo = mock.Mock()
+    repo.get_shifts_for_user = []
     new_shifts = [
         domain_work_shifts[2].to_dict(),
         WorkShift(

--- a/server/tests/use_cases/test_add_workshifts.py
+++ b/server/tests/use_cases/test_add_workshifts.py
@@ -110,7 +110,7 @@ def test_workshift_add_multiple_use_case_no_overlap():
 
 def test_workshift_add_multiple_use_case_timestamps(domain_work_shifts):
     repo = mock.Mock()
-    repo.get_shifts_for_user = []
+    repo.get_shifts_for_user.return_value = []
     new_shifts = [
         domain_work_shifts[2].to_dict(),
         WorkShift(

--- a/server/tests/use_cases/test_add_workshifts.py
+++ b/server/tests/use_cases/test_add_workshifts.py
@@ -120,10 +120,10 @@ def test_workshift_add_multiple_use_case_timestamps(domain_work_shifts):
         ).to_dict(),
     ]
    
-    workshift_add_use_case(repo, new_shifts)
+    workshift_add_multiple_use_case(repo, new_shifts)
     user_id = domain_work_shifts[2]["worker"]
     responses = repo.get_shifts_for_user(user_id)
     assert len(responses) == 2
     assert responses[0]["end_time"] == responses[1]["start_time"]
-    
+
 # pylint: enable=redefined-outer-name

--- a/server/tests/use_cases/test_add_workshifts.py
+++ b/server/tests/use_cases/test_add_workshifts.py
@@ -107,4 +107,23 @@ def test_workshift_add_multiple_use_case_no_overlap():
     assert responses[1]["success"] is True
     repo.add.assert_any_call(shift_1.to_dict())
     repo.add.assert_any_call(shift_2.to_dict())
+
+def test_workshift_add_multiple_use_case_timestamps(domain_work_shifts):
+    repo = mock.Mock()
+    new_shifts = [
+        domain_work_shifts[2].to_dict(),
+        WorkShift(
+            worker="volunteer3@slu.edu",
+            shelter="shelter-id-for-st-patric-center",
+            start_time=1701453600000,
+            end_time=1801453600000,
+        ).to_dict(),
+    ]
+   
+    workshift_add_use_case(repo, new_shifts)
+    user_id = domain_work_shifts[2]["worker"]
+    responses = repo.get_shifts_for_user(user_id)
+    assert len(responses) == 2
+    assert responses[0]["end_time"] == responses[1]["start_time"]
+    
 # pylint: enable=redefined-outer-name

--- a/server/tests/use_cases/test_add_workshifts.py
+++ b/server/tests/use_cases/test_add_workshifts.py
@@ -120,9 +120,8 @@ def test_workshift_add_multiple_use_case_timestamps(domain_work_shifts):
             end_time=1801453600000,
         ).to_dict(),
     ]
-   
     workshift_add_multiple_use_case(repo, new_shifts)
-    user_id = domain_work_shifts[2]["worker"]
+    user_id = domain_work_shifts[2].worker
     responses = repo.get_shifts_for_user(user_id)
     assert len(responses) == 2
     assert responses[0]["end_time"] == responses[1]["start_time"]

--- a/server/tests/use_cases/test_add_workshifts.py
+++ b/server/tests/use_cases/test_add_workshifts.py
@@ -114,7 +114,7 @@ def test_workshift_add_multiple_use_case_timestamps(domain_work_shifts):
     new_shifts = [
         domain_work_shifts[2].to_dict(),
         WorkShift(
-            worker="volunteer3@slu.edu",
+            worker="volunteer@slu.edu",
             shelter="shelter-id-for-st-patric-center",
             start_time=1701453600000,
             end_time=1801453600000,


### PR DESCRIPTION
Fixes #62 

**What was changed?**

Modified individualShelter.js

**Why was it changed?**

The timestamps being recorded for consecutive shifts weren't consistent (the time stamp given for the end of a shift at 3 pm and the start of another shift at 3 pm were different). 

**How was it changed?**

On individualShelter.js I changed lines 17 and 20 to set the milliseconds and seconds to 0. The new Date() wasn't getting the milliseconds and seconds attribute set to 0, so it would have the current difference in time from the milliseconds and seconds accounted into the timestamp. However natively for choosing times ahead (not the ones initially displayed on the page) minutes, seconds, and milliseconds are set to 0. Now the first displayed page time reflects that. 