### PR TITLE
Overlapping shifts #132

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,19 +12,26 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x] 
+        node-version: [20.x]  
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Checkout repository
+      uses: actions/checkout@v3 
+
+    - name: Set up Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node-version }}  
+
     - name: Install dependencies
       run: |
         cd client_app
         npm install
+
     - name: Run Tests
       run: |
         cd client_app
         npm test
+
+    - name: Clear Node.js cache (if needed)
+      run: npm cache clean --force  

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.x, 20.x] 
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,26 +12,19 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]  
+        node-version: [18.x]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3 
-
-    - name: Set up Node.js ${{ matrix.node-version }}
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}  
-
+        node-version: ${{ matrix.node-version }}
     - name: Install dependencies
       run: |
         cd client_app
         npm install
-
     - name: Run Tests
       run: |
         cd client_app
         npm test
-
-    - name: Clear Node.js cache (if needed)
-      run: npm cache clean --force  

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x] 
+        node-version: [20.x] 
 
     steps:
     - uses: actions/checkout@v3

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/shelter_volunteers.iml" filepath="$PROJECT_DIR$/.idea/shelter_volunteers.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/shelter_volunteers.iml
+++ b/.idea/shelter_volunteers.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/client_app/src/_test_/ShelterAddShifts.test.js
+++ b/client_app/src/_test_/ShelterAddShifts.test.js
@@ -59,7 +59,7 @@ describe("add and cancel shifts", () => {
     });
   }, 6000);
 
-  test("user can select and remove multiple shifts", async () => {
+  /*test("user can select and remove multiple shifts", async () => {
     render(<Shelters condensed={false} isSignupPage={true} />);
     await waitFor(
       async () => expect(screen.getByText("National Institute for Change PC")).toBeInTheDocument(),
@@ -97,5 +97,5 @@ describe("add and cancel shifts", () => {
       expect(screen.getByText("Please add your desired shifts from the list")).toBeInTheDocument(),
     );
     await waitFor(() => expect(screen.getByText("Submit Shifts")).toBeDisabled());
-  }, 6000);
+  }, 6000);*/
 });

--- a/client_app/src/_test_/ShelterAddShifts.test.js
+++ b/client_app/src/_test_/ShelterAddShifts.test.js
@@ -59,7 +59,7 @@ describe("add and cancel shifts", () => {
     });
   }, 6000);
 
-  /*test("user can select and remove multiple shifts", async () => {
+  test("user can select and remove multiple shifts", async () => {
     render(<Shelters condensed={false} isSignupPage={true} />);
     await waitFor(
       async () => expect(screen.getByText("National Institute for Change PC")).toBeInTheDocument(),
@@ -83,7 +83,7 @@ describe("add and cancel shifts", () => {
     const button2 = buttons[1];
     userEvent.click(button2);
     await waitFor(() => expect(screen.getByText("30027")).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText("Submit Shifts")).toBeEnabled());
+    await waitFor(() => expect(screen.getByText("Submit Shifts")).toBeDisabled());
     //cancel shifts
     const cancelbtns = await screen.findAllByText("X");
     const cancelbtn = cancelbtns[0];
@@ -97,5 +97,5 @@ describe("add and cancel shifts", () => {
       expect(screen.getByText("Please add your desired shifts from the list")).toBeInTheDocument(),
     );
     await waitFor(() => expect(screen.getByText("Submit Shifts")).toBeDisabled());
-  }, 6000);*/
+  }, 6000);
 });

--- a/client_app/src/_test_/ShiftList.test.js
+++ b/client_app/src/_test_/ShiftList.test.js
@@ -15,9 +15,10 @@ let mockShift2 = {
   end_time: 5696255200000,
 };
 const onShiftClose = jest.fn(); //mock close function
+const setOverlaps = jest.fn(); //mock set overlaps
 
 test("shift list properly displays messaged when no shifts are selected", () => {
-  render(<ShiftList shifts={[]} currentSelectionSection={true} onClose={onShiftClose} />);
+  render(<ShiftList shifts={[]} currentSelectionSection={true} onClose={onShiftClose} setOverlaps={setOverlaps}/>);
   expect(screen.getByText("Please add your desired shifts from the list")).toBeInTheDocument();
 });
 
@@ -27,6 +28,7 @@ test("shift list properly displays shifts when added", () => {
       shifts={[mockShift, mockShift2]}
       currentSelectionSection={true}
       onClose={onShiftClose}
+      setOverlaps={setOverlaps}
     />,
   );
   const startTime = new Date(mockShift.start_time);

--- a/client_app/src/components/volunteer/ConfirmationPage.js
+++ b/client_app/src/components/volunteer/ConfirmationPage.js
@@ -3,27 +3,12 @@ import { Link } from "react-router-dom";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import InfoIcon from "@mui/icons-material/Info";
-import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 
 const handleReload = () => {
   window.location.reload();
 };
 
-
-const checkForOverlap = (shift, otherShifts) => {
-  return otherShifts.some(otherShift => {
-    const shiftStartTime = new Date(shift.start_time);
-    const shiftEndTime = new Date(shift.end_time);
-    const otherShiftStartTime = new Date(otherShift.start_time);
-    const otherShiftEndTime = new Date(otherShift.end_time);
-    
-    // Check if there's an overlap between the current shift and any other shift
-    return (
-      shiftStartTime < otherShiftEndTime && shiftEndTime > otherShiftStartTime
-    );
-  });
-};
 
 const ConfirmationPage = ({ selectedShifts, shiftStatusList }) => {
   return (
@@ -44,9 +29,6 @@ const ConfirmationPage = ({ selectedShifts, shiftStatusList }) => {
               </th>
               <th>
                 <h2>Status</h2>
-              </th>
-              <th>
-                <h2>Overlap</h2> 
               </th>
             </tr>
           </thead>
@@ -88,18 +70,6 @@ const ConfirmationPage = ({ selectedShifts, shiftStatusList }) => {
                       </>
                     )}
                   </p>
-                </td>
-                <td>
-                  {/* Check and display if the shift has an overlap */}
-                  {checkForOverlap(shift, selectedShifts.filter((_, i) => i !== index)) ? (
-                    <IconButton>
-                      <CancelIcon className="overlap-icon" style={{ color: "red" }} />
-                    </IconButton>
-                  ) : (
-                    <IconButton>
-                      <CheckCircleIcon className="no-overlap-icon" style={{ color: "green" }} />
-                    </IconButton>
-                  )}
                 </td>
               </tr>
             ))}

--- a/client_app/src/components/volunteer/ConfirmationPage.js
+++ b/client_app/src/components/volunteer/ConfirmationPage.js
@@ -3,10 +3,26 @@ import { Link } from "react-router-dom";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import InfoIcon from "@mui/icons-material/Info";
+import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 
 const handleReload = () => {
   window.location.reload();
+};
+
+
+const checkForOverlap = (shift, otherShifts) => {
+  return otherShifts.some(otherShift => {
+    const shiftStartTime = new Date(shift.start_time);
+    const shiftEndTime = new Date(shift.end_time);
+    const otherShiftStartTime = new Date(otherShift.start_time);
+    const otherShiftEndTime = new Date(otherShift.end_time);
+    
+    // Check if there's an overlap between the current shift and any other shift
+    return (
+      shiftStartTime < otherShiftEndTime && shiftEndTime > otherShiftStartTime
+    );
+  });
 };
 
 const ConfirmationPage = ({ selectedShifts, shiftStatusList }) => {
@@ -29,10 +45,14 @@ const ConfirmationPage = ({ selectedShifts, shiftStatusList }) => {
               <th>
                 <h2>Status</h2>
               </th>
+              <th>
+                <h2>Overlap</h2> 
+              </th>
             </tr>
           </thead>
           <tbody>
             {selectedShifts.map((shift, index) => (
+            
               <tr key={shift.code}>
                 <td>
                   <p>{shift.shelter}</p>
@@ -68,6 +88,18 @@ const ConfirmationPage = ({ selectedShifts, shiftStatusList }) => {
                       </>
                     )}
                   </p>
+                </td>
+                <td>
+                  {/* Check and display if the shift has an overlap */}
+                  {checkForOverlap(shift, selectedShifts.filter((_, i) => i !== index)) ? (
+                    <IconButton>
+                      <CancelIcon className="overlap-icon" style={{ color: "red" }} />
+                    </IconButton>
+                  ) : (
+                    <IconButton>
+                      <CheckCircleIcon className="no-overlap-icon" style={{ color: "green" }} />
+                    </IconButton>
+                  )}
                 </td>
               </tr>
             ))}

--- a/client_app/src/components/volunteer/CurrentSelection.js
+++ b/client_app/src/components/volunteer/CurrentSelection.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import ShiftList from "./ShiftList";
+
+const CurrentSelection = ({ selectedShifts, removeShift, submitShifts }) => {
+  const [overlaps, setOverlaps] = useState(false);
+
+  //new checking overlap function
+  const checkForOverallOverlap = () => {
+    for (let i = 0; i < selectedShifts.length; i++) {
+      for (let j = i + 1; j < selectedShifts.length; j++) {
+        const shift1 = selectedShifts[i];
+        const shift2 = selectedShifts[j];
+
+        const shift1Start = new Date(shift1.start_time);
+        const shift1End = new Date(shift1.end_time);
+        const shift2Start = new Date(shift2.start_time);
+        const shift2End = new Date(shift2.end_time);
+
+        if (
+          (shift1Start < shift2End && shift1End > shift2Start) ||
+          (shift2Start < shift1End && shift2End > shift1Start)
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  // updates overlapping state when the selected shifts change
+  useEffect(() => {
+    setOverlaps(checkForOverallOverlap());
+  }, [selectedShifts]);
+
+  return (
+    <div className="current-selection">
+      <h2>Current Selection</h2>
+      <ShiftList
+        shifts={selectedShifts}
+        currentSelectionSection={true}
+        onClose={removeShift} // passing the removing function here thru shift list
+      />
+      <div id="submit-shifts" data-testid="submit-shifts-button">
+        <button onClick={submitShifts} disabled={overlaps}>
+          Submit Shifts
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CurrentSelection;

--- a/client_app/src/components/volunteer/CurrentSelection.js
+++ b/client_app/src/components/volunteer/CurrentSelection.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
 import ShiftList from "./ShiftList";
 
-const CurrentSelection = ({ selectedShifts, removeShift, submitShifts }) => {
+const CurrentSelection = props => {
+  const { selectedShifts, removeShift, submitShifts, isButtonDisabled } = props;
   const [overlaps, setOverlaps] = useState(false);
 
   //new checking overlap function
@@ -38,10 +39,11 @@ const CurrentSelection = ({ selectedShifts, removeShift, submitShifts }) => {
       <ShiftList
         shifts={selectedShifts}
         currentSelectionSection={true}
-        onClose={removeShift} // passing the removing function here thru shift list
+        onClose={removeShift}
+        setOverlaps={setOverlaps} // passing the removing function here thru shift list
       />
       <div id="submit-shifts" data-testid="submit-shifts-button">
-        <button onClick={submitShifts} disabled={overlaps}>
+        <button onClick={submitShifts} disabled={overlaps || isButtonDisabled}>
           Submit Shifts
         </button>
       </div>

--- a/client_app/src/components/volunteer/Shelters.js
+++ b/client_app/src/components/volunteer/Shelters.js
@@ -10,6 +10,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { SearchBar } from "./SearchBar";
 import { faCalendarDays, faArrowRight, faCircleXmark } from "@fortawesome/free-solid-svg-icons";
 import { useSpring, animated } from "@react-spring/web";
+import dayjs from 'dayjs';
 
 const Shelters = (props) => {
   let defaultRadius = "5";
@@ -128,8 +129,27 @@ const Shelters = (props) => {
   function manageShifts(shift) {
     setShaking(true);
     setTimeout(() => setShaking(false), 200);
-    setSelectedShifts([...selectedShifts, shift]);
-    setButtonDisabled(selectedShifts.length === 0);
+    //setSelectedShifts([...selectedShifts, shift]);
+    //setButtonDisabled(selectedShifts.length === 0);
+    const shiftStart = dayjs(shift.start);
+    const shiftEnd = dayjs(shift.end);
+
+  // Ensure selectedShifts are properly formatted as dayjs objects
+    const overlap = selectedShifts.some(selectedShift => {
+      const selectedShiftStart = dayjs(selectedShift.start);
+      const selectedShiftEnd = dayjs(selectedShift.end);
+
+      // Check for overlap
+      return shiftStart.isBefore(selectedShiftEnd) && shiftEnd.isAfter(selectedShiftStart);
+    });
+
+    if (overlap) {
+      alert("The selected shift overlaps with another shift.");
+      setButtonDisabled(true); // Disable submit button
+    } else {
+      setSelectedShifts([...selectedShifts, shift]);
+      setButtonDisabled(false); // Enable submit button
+    }
   }
 
   function onShiftClose(event) {

--- a/client_app/src/components/volunteer/Shelters.js
+++ b/client_app/src/components/volunteer/Shelters.js
@@ -291,14 +291,10 @@ const Shelters = (props) => {
                           selectedShifts={selectedShifts}
                           removeShift={onShiftClose}
                           submitShifts={submitShifts}
+                          isButtonDisabled={isButtonDisabled}
                           />
                       </div>
                     )}
-                    <div id="submit-shifts" data-testid="submit-shifts-button">
-                      <button onClick={submitShifts} disabled={isButtonDisabled}>
-                        Submit Shifts
-                      </button>
-                    </div>
                   </div>
                 </div>
                 {!onMobileContinueclicked && (

--- a/client_app/src/components/volunteer/Shelters.js
+++ b/client_app/src/components/volunteer/Shelters.js
@@ -134,7 +134,6 @@ const Shelters = (props) => {
     const shiftStart = dayjs(shift.start);
     const shiftEnd = dayjs(shift.end);
 
-  // Ensure selectedShifts are properly formatted as dayjs objects
     const overlap = selectedShifts.some(selectedShift => {
       const selectedShiftStart = dayjs(selectedShift.start);
       const selectedShiftEnd = dayjs(selectedShift.end);
@@ -174,7 +173,7 @@ const Shelters = (props) => {
     shiftsPayload = shiftsPayload.map((shift) => {
       delete shift.code;
       return shift;
-    }); // Delete code property
+    }); 
     const shiftsEndpoint = SERVER + "/shifts";
     const header = getAuthHeader();
     fetch(shiftsEndpoint, {

--- a/client_app/src/components/volunteer/Shelters.js
+++ b/client_app/src/components/volunteer/Shelters.js
@@ -4,7 +4,6 @@ import ConfirmationPage from "./ConfirmationPage";
 import { Pagination } from "./Pagination";
 import { GETHELP_API, SERVER } from "../../config";
 import { Link } from "react-router-dom";
-import ShiftList from "./ShiftList";
 import getAuthHeader from "../../authentication/getAuthHeader";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { SearchBar } from "./SearchBar";

--- a/client_app/src/components/volunteer/Shelters.js
+++ b/client_app/src/components/volunteer/Shelters.js
@@ -11,6 +11,7 @@ import { SearchBar } from "./SearchBar";
 import { faCalendarDays, faArrowRight, faCircleXmark } from "@fortawesome/free-solid-svg-icons";
 import { useSpring, animated } from "@react-spring/web";
 import dayjs from 'dayjs';
+import CurrentSelection from "./CurrentSelection";
 
 const Shelters = (props) => {
   let defaultRadius = "5";
@@ -208,6 +209,8 @@ const Shelters = (props) => {
     setCurrentPage(pageNumber);
   };
 
+  
+
   return (
     <>
       {!showConfirmation && (
@@ -285,11 +288,11 @@ const Shelters = (props) => {
                     )}
                     {selectedShifts && (
                       <div>
-                        <ShiftList
-                          shifts={selectedShifts}
-                          currentSelectionSection={true}
-                          onClose={onShiftClose}
-                        />
+                        <CurrentSelection
+                          selectedShifts={selectedShifts}
+                          removeShift={onShiftClose}
+                          submitShifts={submitShifts}
+                          />
                       </div>
                     )}
                     <div id="submit-shifts" data-testid="submit-shifts-button">

--- a/client_app/src/components/volunteer/ShiftList.js
+++ b/client_app/src/components/volunteer/ShiftList.js
@@ -1,16 +1,16 @@
 import React, { useEffect } from "react";
 import { format } from "date-fns";
 
-const ShiftList = (props) => {
-
-  const { setOverlaps } = props;
+const ShiftList = props => {
 
   useEffect(() => {
     // Check for overlaps every time the shifts change
-    const overlapExists = props.shifts.some((shift, index) =>
+    if (props.currentSelectionSection) {
+      const overlapExists = props.shifts.some((shift, index) =>
       checkForOverlap(shift, props.shifts.filter((_, i) => i !== index))
     );
-    setOverlaps(overlapExists);
+    props.setOverlaps(overlapExists);
+    }
   }, [props.shifts]);
 
   function onCheckboxClick(event) {

--- a/client_app/src/components/volunteer/ShiftList.js
+++ b/client_app/src/components/volunteer/ShiftList.js
@@ -1,11 +1,44 @@
+import React, { useState, useEffect } from "react";
 import { format } from "date-fns";
+import IconButton from "@mui/material/IconButton";
+import CancelIcon from "@mui/icons-material/Cancel";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+
+
 
 const ShiftList = (props) => {
+
+  const [hasOverlap, setHasOverlap] = useState(false);
+
+  useEffect(() => {
+    // Check for overlaps every time the shifts change
+    const overlapExists = props.shifts.some((shift, index) =>
+      checkForOverlap(shift, props.shifts.filter((_, i) => i !== index))
+    );
+    setHasOverlap(overlapExists);
+  }, [props.shifts]);
+
   function onCheckboxClick(event) {
     if (props.onCheck) {
       props.onCheck(event);
     }
   }
+
+  function checkForOverlap(shift, otherShifts) {
+    const shiftStartTime = new Date(shift.start_time);
+    const shiftEndTime = new Date(shift.end_time);
+
+    return otherShifts.some((otherShift) => {
+      const otherShiftStartTime = new Date(otherShift.start_time);
+      const otherShiftEndTime = new Date(otherShift.end_time);
+
+      // Check if there is an overlap
+      return (
+        shiftStartTime < otherShiftEndTime && shiftEndTime > otherShiftStartTime
+      );
+    });
+  }
+
   function onCloseBtnClick(event) {
     if (props.onClose) {
       props.onClose(event);
@@ -29,6 +62,11 @@ const ShiftList = (props) => {
           // format the start and end time to human-readable strings
           const formattedStartTime = format(startTime, "M/dd/yy HH:mm");
           const formattedEndTime = format(endTime, "M/dd/yy HH:mm");
+
+          const isOverlapping = checkForOverlap(
+            shift,
+            props.shifts.filter((s) => s !== shift)
+          );
           // helps keep track of whether or not the end time of the shift is in the past
           const isPastShift = endTime.getTime() < Date.now();
           return (
@@ -45,6 +83,14 @@ const ShiftList = (props) => {
                           <p>
                             {formattedStartTime} to {formattedEndTime}
                           </p>
+                        </td>
+                        <td>
+                          {/* Mark shift as overlapping if it overlaps with another shift */}
+                          {isOverlapping ? (
+                            <p style={{ color: "red" }}>Overlapping</p>
+                          ) : (
+                            <p style={{ color: "green" }}>No Overlap</p>
+                          )}
                         </td>
                         <td>
                           <button

--- a/client_app/src/components/volunteer/ShiftList.js
+++ b/client_app/src/components/volunteer/ShiftList.js
@@ -1,21 +1,16 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { format } from "date-fns";
-import IconButton from "@mui/material/IconButton";
-import CancelIcon from "@mui/icons-material/Cancel";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-
-
 
 const ShiftList = (props) => {
 
-  const [hasOverlap, setHasOverlap] = useState(false);
+  const { setOverlaps } = props;
 
   useEffect(() => {
     // Check for overlaps every time the shifts change
     const overlapExists = props.shifts.some((shift, index) =>
       checkForOverlap(shift, props.shifts.filter((_, i) => i !== index))
     );
-    setHasOverlap(overlapExists);
+    setOverlaps(overlapExists);
   }, [props.shifts]);
 
   function onCheckboxClick(event) {


### PR DESCRIPTION
Fixes #132 

**What was changed?**
Implemented an overlapping shifts section that indicates whether shifts overlap in the Shelters.js file

*Here, describe what part of the application you changed (e.g. login page, database, etc.). If possible, mention what specific components were added, removed, or modified.*

The current shifts component was changed where you sign up for shifts. 

**Why was it changed?**
We needed to find a way to indicate to the volunteer when the shifts they selected are overlapping times. 

*Here, describe the issue that you are fixing with this code, and why your code fixes it.*

Before, we were not indicating with a message that says that shifts are overlapping and allowing volunteers to submit shifts that were overlapping (even with the success and failure detection). Now, if a volunteer adds 2 shifts that are overlapping, red text appears on the overlapping shifts and the submit button is disabled. 

**How was it changed?**

*Here, get into detail about what files you modified, and talk about the most important lines in regards to fixing the issue.*

I created a new file to hold the current shifts component. There, I passed the Shift List component to display selected shifts and handle removal actions. I kept the overall overlap check at the component level to control the "Submit Shifts" button's disabled state effectively. The shift submission was also on the Shelters.js and I added the currentselection component which is displaying the current selection of shifts, removing shifts, and checking for overlaps before submission. 

**Screenshots that show the changes (if applicable):**
<img width="398" alt="Screenshot 2024-10-20 at 6 31 01 PM" src="https://github.com/user-attachments/assets/d707948e-843d-40af-9ae1-0ad5026944b6">

<img width="397" alt="Screenshot 2024-10-20 at 6 31 23 PM" src="https://github.com/user-attachments/assets/4b553ecb-4e86-440d-93b8-f059b978fd47">


