### PR TITLE
Implement Validations for Time Input, Overlapping Events, and Prevent Past Date Event Creation (#136) fixed

### DIFF
--- a/client_app/src/components/shelter/NavBarShelterDashboard.js
+++ b/client_app/src/components/shelter/NavBarShelterDashboard.js
@@ -35,7 +35,7 @@ function CustomNavBarShelter({ auth }) {
                 <Nav.Link
                   href="/request-for-help"
                   active={location.pathname === "/request-for-help"}>
-                  Request For Help
+                  Set Shifts
                 </Nav.Link>
                 <Nav.Link href="/cancel-shifts" active={location.pathname === "/cancel-shifts"}>
                   Cancel Shifts

--- a/client_app/src/components/shelter/RequestForHelp.js
+++ b/client_app/src/components/shelter/RequestForHelp.js
@@ -23,6 +23,7 @@ export default function RequestForHelp() {
       setShowErrorModal(true);
       return;
     }
+
     setNewEvent({ ...newEvent, title: "", start, end, volunteersRequired: "" })
     setSelectedEvent(null)
     setVolunteerError("")
@@ -37,18 +38,26 @@ export default function RequestForHelp() {
   }, [])
 
   const handleSaveEvent = () => {
-    if (newEvent.volunteersRequired) {
-      const newEventStart = new Date(newEvent.start);
-      const newEventEnd = new Date(newEvent.end);
+    if (newEvent.volunteersRequired && newEvent.start && newEvent.end) {
+      if (parseInt(newEvent.volunteersRequired) <= 0) {
+        setVolunteerError("'Number of Volunteers Required' needs to be greater than 0");
+        return;
+      }
 
       const isOverlapping = myEvents.some((event) => {
+        if (
+          selectedEvent &&
+          event.start === selectedEvent.start &&
+          event.end === selectedEvent.end
+        ) {
+          return false;
+        }
+    
         const eventStart = new Date(event.start);
         const eventEnd = new Date(event.end);
-        return (
-          (newEventStart < eventEnd && newEventEnd > eventStart) 
-        );
+        return newEvent.start < eventEnd && newEvent.end > eventStart;
       });
-
+    
       if (isOverlapping) {
         setVolunteerError("This shift overlaps with an existing shift.");
         return;
@@ -74,13 +83,16 @@ export default function RequestForHelp() {
               : ev
           )
         );
-     } else {
+      } else {
         setEvents((prev) => [...prev, formattedEvent])
       }
       setVolunteerError("");
       setShowModal(false)
     } else if (!newEvent.volunteersRequired) {
-      setVolunteerError("'Number of Volunteers Required' field is required.");
+      setVolunteerError("'Number of Volunteers Required' field is numeric.");
+      return;
+    } else {
+      setVolunteerError("Required fields cannot be empty.");
       return;
     }
 
@@ -98,30 +110,31 @@ export default function RequestForHelp() {
   const handleVolunteerInputChange = (e) => {
     const { name, value } = e.target;
     if (name === "volunteersRequired") {
-      const volunteersValue = Math.max(0, parseInt(value) || "");
+      const volunteersValue = parseInt(value);
       setNewEvent((prev) => ({
         ...prev,
         volunteersRequired: volunteersValue,
       }));
     }
     if (name === "start" || name === "end") {
-      setNewEvent((prev) => {
-        const current = prev[name] ? dayjs(prev[name]) : dayjs(); 
-        const [hour, minute] = value.split(":");
-  
-        const updatedDate = current
-          .hour(parseInt(hour, 10))
-          .minute(parseInt(minute, 10))
-          .second(0)
-          .millisecond(0);
-  
-        return {
+      if (value === "") {
+        setNewEvent((prev) => ({
           ...prev,
-          [name]: updatedDate.toDate(),
-        };
-      });
-    } else {
-      setNewEvent((prev) => ({ ...prev, [name]: value }));
+          [name]: null,
+        }));
+      } else {
+        setNewEvent((prev) => {
+          const [hour, minute] = value.split(":");
+          const updatedDate = prev[name]
+            ? dayjs(prev[name]).hour(parseInt(hour, 10)).minute(parseInt(minute, 10)).second(0).millisecond(0)
+            : dayjs().hour(parseInt(hour, 10)).minute(parseInt(minute, 10)).second(0).millisecond(0);
+    
+          return {
+            ...prev,
+            [name]: updatedDate.toDate(),
+          };
+        });
+      }
     }
   };
 
@@ -153,7 +166,8 @@ export default function RequestForHelp() {
                   setNewEvent({ ...newEvent, title: e.target.value || ""})
                 }
               />
-              <Form.Label>Start Time:</Form.Label>
+              <Form.Label>Start Time <span style={{ color: "red" }}>*</span>
+              </Form.Label>
               <Form.Control
                 type="time"
                 name="start"
@@ -162,7 +176,8 @@ export default function RequestForHelp() {
                   target: { name: "start", value: e.target.value }
                 })}
               />
-              <Form.Label>End Time:</Form.Label>
+              <Form.Label>End Time <span style={{ color: "red" }}>*</span>
+              </Form.Label>
               <Form.Control
                 type="time"
                 name="end"
@@ -171,7 +186,8 @@ export default function RequestForHelp() {
                   target: { name: "end", value: e.target.value }
                 })}
               />
-              <Form.Label>Number of Volunteers Required</Form.Label>
+              <Form.Label>Number of Volunteers Required <span style={{ color: "red" }}>*</span>
+              </Form.Label>
               <div className="d-flex align-items-center">
                 <Form.Control
                   type="number"

--- a/client_app/src/components/shelter/RequestForHelp.js
+++ b/client_app/src/components/shelter/RequestForHelp.js
@@ -147,6 +147,7 @@ export default function RequestForHelp() {
           localizer={localizer}
           onSelectEvent={handleSelectEvent}
           onSelectSlot={handleSelectSlot}
+          views={[Views.WEEK, Views.DAY]}
           selectable
         />
       </div>


### PR DESCRIPTION
Fixes #136 

**What was changed?**

I changed the Request for Help page.

**Why was it changed?**

It was changed because currently, users could select past dates to sign up for shifts and register for overlapping shifts. Additionally, there was no warning message for an empty start time or end time.

**How was it changed?**

I added conditions to check for overlapping shifts and if the user selected a past date. I made a new modal to display an error message for past dates. I also added some conditions to check if the required files are empty and to ensure that the number of volunteers required is always greater than 0. 

**Screenshots that show the changes (if applicable):**
<img width="495" alt="Screenshot 2024-10-24 at 1 06 12 PM" src="https://github.com/user-attachments/assets/d5d2702a-1ed2-4e83-892f-f7d76bda2b57">
<img width="734" alt="Screenshot 2024-11-01 at 4 04 48 PM" src="https://github.com/user-attachments/assets/7a6cc104-2923-4a97-b8a3-02701e64450f">
<img width="399" alt="Screenshot 2024-11-01 at 4 02 26 PM" src="https://github.com/user-attachments/assets/8776c194-6e89-4a90-b5f9-06ccf5606ff8">
<img width="403" alt="Screenshot 2024-11-01 at 4 03 59 PM" src="https://github.com/user-attachments/assets/6f79a7b7-6ba6-4ecd-85cb-84de91cee21e">

