### PR TITLE
Fixed (Issue #137) Updated styling of shift details page and convert time format from UNIX 

### DIFF
--- a/client_app/package-lock.json
+++ b/client_app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "client_app",
       "version": "0.1.0",
       "dependencies": {
-        "@emotion/react": "^11.11.4",
+        "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.11.0",
         "@fortawesome/fontawesome-svg-core": "^6.4.2",
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
@@ -17,6 +17,7 @@
         "@mui/material": "^5.15.14",
         "@mui/x-date-pickers": "^7.17.0",
         "@react-spring/web": "^9.7.3",
+        "@table-library/react-table-library": "^4.1.7",
         "@testing-library/user-event": "^13.5.0",
         "bootstrap": "^5.3.2",
         "chart.js": "^4.4.0",
@@ -2350,15 +2351,15 @@
       }
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
-      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
+      "integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.1",
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/serialize": "^1.1.2",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.2.0",
         "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
@@ -2366,6 +2367,11 @@
         "source-map": "^0.5.7",
         "stylis": "4.2.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2387,21 +2393,26 @@
       }
     },
     "node_modules/@emotion/cache": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "version": "11.13.1",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
+      "integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/sheet": "^1.2.2",
-        "@emotion/utils": "^1.2.1",
-        "@emotion/weak-memoize": "^0.3.1",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.0",
+        "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
       }
     },
+    "node_modules/@emotion/cache/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
     "node_modules/@emotion/hash": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
@@ -2417,17 +2428,17 @@
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/react": {
-      "version": "11.11.4",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
-      "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
+      "version": "11.13.3",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
+      "integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.11.0",
-        "@emotion/cache": "^11.11.0",
-        "@emotion/serialize": "^1.1.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-        "@emotion/utils": "^1.2.1",
-        "@emotion/weak-memoize": "^0.3.1",
+        "@emotion/babel-plugin": "^11.12.0",
+        "@emotion/cache": "^11.13.0",
+        "@emotion/serialize": "^1.3.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+        "@emotion/utils": "^1.4.0",
+        "@emotion/weak-memoize": "^0.4.0",
         "hoist-non-react-statics": "^3.3.1"
       },
       "peerDependencies": {
@@ -2440,21 +2451,26 @@
       }
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz",
-      "integrity": "sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.2.tgz",
+      "integrity": "sha512-grVnMvVPK9yUVE6rkKfAJlYZgo0cu3l9iMC77V7DW6E1DUIrU68pSEXRmFZFOFB1QFo57TncmOcvcbMDWsL4yA==",
       "dependencies": {
-        "@emotion/hash": "^0.9.1",
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/unitless": "^0.8.1",
-        "@emotion/utils": "^1.2.1",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.1",
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
     "node_modules/@emotion/sheet": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
     },
     "node_modules/@emotion/styled": {
       "version": "11.11.0",
@@ -2479,27 +2495,27 @@
       }
     },
     "node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
+      "integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.1.tgz",
+      "integrity": "sha512-BymCXzCG3r72VKJxaYVwOXATqXIZ85cuvg0YOUDxMGNrKc1DJRZk8MgV5wyXRyEayIMd4FuXJIUgTBXvDNW5cA=="
     },
     "node_modules/@emotion/weak-memoize": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
-      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -5625,6 +5641,29 @@
       "integrity": "sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@table-library/react-table-library": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@table-library/react-table-library/-/react-table-library-4.1.7.tgz",
+      "integrity": "sha512-KKFjdACvEUeD9yhgXBjZUJSdE9pxUbJdou4Pp71FW8dxQWc7LcMcSxpveSfGXw8KlcWY0hThJOwyjQb+UKOmnw==",
+      "dependencies": {
+        "clsx": "1.1.1",
+        "react-virtualized-auto-sizer": "1.0.7",
+        "react-window": "1.8.7"
+      },
+      "peerDependencies": {
+        "@emotion/react": ">= 11",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@table-library/react-table-library/node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -20998,6 +21037,39 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz",
+      "integrity": "sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==",
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.7.tgz",
+      "integrity": "sha512-JHEZbPXBpKMmoNO1bNhoXOOLg/ujhL/BU4IqVU9r8eQPcy5KQnGHIHDRkJ0ns9IM5+Aq5LNwt3j8t3tIrePQzA==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-window/node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/client_app/package.json
+++ b/client_app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@emotion/react": "^11.11.4",
+    "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.11.0",
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
@@ -12,6 +12,7 @@
     "@mui/material": "^5.15.14",
     "@mui/x-date-pickers": "^7.17.0",
     "@react-spring/web": "^9.7.3",
+    "@table-library/react-table-library": "^4.1.7",
     "@testing-library/user-event": "^13.5.0",
     "bootstrap": "^5.3.2",
     "chart.js": "^4.4.0",

--- a/client_app/src/components/shelter/EditStatusConfirmationModal.js
+++ b/client_app/src/components/shelter/EditStatusConfirmationModal.js
@@ -1,6 +1,8 @@
 import React from 'react'; 
 import { ModalComponent } from './ModalComponent';
 import { ENVIROMENT } from '../../config.js';
+import "../../styles/shelter/confirmStatusModal.css"
+import { format } from "date-fns";
 
 export const EditStatusConfirmationModal = props => {
   const {isStatusModalOpen, setIsStatusModalOpen, shift} = props;
@@ -19,13 +21,19 @@ export const EditStatusConfirmationModal = props => {
   const renderData = () => {
     return (
       <div>
-        <p> Do you want to {!shift.status ? "open" : "close"} volunteer shift registration on {shift.date} from {shift.startTime} to {shift.endTime}? </p>
-        <button onClick={() => onYesClick()}>
-          Yes
-        </button>
-        <button onClick={() => onNoClick()}>
-          No
-        </button>
+        <div className="confirmationMessage">
+          <span>
+            Do you want to <b>{!shift.status ? "open" : "close"}</b> volunteer registration on <b>{format(shift.startTime, "MM/dd/yyyy")}</b> from <b>{format(shift.startTime, "hh:mm aaaaa'm'")}</b> to <b>{format(shift.endTime, "hh:mm aaaaa'm'")}</b>?
+          </span>
+        </div>
+        <div className="buttonContainer">
+          <button className="yesStatusButton" onClick={() => onYesClick()}>
+            Yes
+          </button>
+          <button className="noStatusButton" onClick={() => onNoClick()}>
+            No
+          </button>
+        </div>
       </div>
     ) 
   }

--- a/client_app/src/components/shelter/EmergencyAlertModal.js
+++ b/client_app/src/components/shelter/EmergencyAlertModal.js
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'; 
 import { ModalComponent } from './ModalComponent';
 import { ENVIROMENT } from '../../config.js';
+import "../../styles/shelter/emergencyAlertModal.css"
 
 export const EmergencyAlertModal = props => {
   const {isEmergencyModalOpen, setIsEmergencyModalOpen} = props;
@@ -31,14 +32,19 @@ export const EmergencyAlertModal = props => {
             Emergency Alert
           </h3>
         </span>
-        <input
-            type="text"
-            value={input}
-            onChange={(e) => handleChange(e.target.value)}
-         />
-        <button disabled={!containsMessage} onClick={() => sendAlert()}>
-          Send
-        </button>
+        <div className="emergencyMessageContainer">
+          <textarea
+              type="text"
+              value={input}
+              onChange={(e) => handleChange(e.target.value)}
+              className="emergencyMessage"
+          />
+        </div>
+        <div className="sendButtonContainer">
+          <button className="sendButton" disabled={!containsMessage} onClick={() => sendAlert()}>
+            Send
+          </button>
+        </div>
       </div>
     ) 
   }

--- a/client_app/src/components/shelter/ShiftDetails.js
+++ b/client_app/src/components/shelter/ShiftDetails.js
@@ -11,12 +11,15 @@ import { ShiftsModal } from "./ShiftsModal.js";
 import { useState } from 'react';
 import { EmergencyAlertModal } from "./EmergencyAlertModal";
 import { EditStatusConfirmationModal } from "./EditStatusConfirmationModal";
-import Box from '@mui/material/Box';
+import { availableShifts } from "./ShiftDetailsData.tsx";
+import OutlinedInput from '@mui/material/OutlinedInput';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
+import ListItemText from '@mui/material/ListItemText';
 import Select from '@mui/material/Select';
-import { availableShifts } from "./ShiftDetailsData.tsx";
+import Checkbox from '@mui/material/Checkbox';
+import { format } from "date-fns";
 
 dayjs.extend(dayjsUTC);
 dayjs.extend(dayjsTimezone);
@@ -27,10 +30,17 @@ export const ShiftDetails = () => {
     const [isStatusModalOpen, setIsStatusModalOpen] = useState(false);
     const [shift, setShift] = useState();
     const shiftsList = availableShifts;
-    const [selectedShifts, setSelectedShift] = useState("");
+    const [selectedShifts, setSelectedShift] = useState([]);
+    const stickyHeader = (isEmergencyModalOpen || isVolunteerModalOpen || isStatusModalOpen) ? "static" : "sticky";
+    const headerZIndex = (isEmergencyModalOpen || isVolunteerModalOpen || isStatusModalOpen) ? 0 : 1;
 
     const handleChange = (event) => {
-      setSelectedShift(event.target.value);
+      const {
+        target: { value },
+      } = event;
+      setSelectedShift(
+        typeof value === 'string' ? value.split(',') : value,
+      );
     };
 
     const onSignUpVolunteersClick = () => {
@@ -48,9 +58,12 @@ export const ShiftDetails = () => {
 
     const renderDropDown = () => {
       return (shiftsList.shifts.map((shiftSlot => {
-        const nameAndTime = shiftSlot.name ? shiftSlot.name + ": " + shiftSlot.startTime + " - " + shiftSlot.endTime : shiftSlot.startTime + " - " + shiftSlot.endTime;
+        const nameAndTime = shiftSlot.name ? shiftSlot.name + ": " + format(shiftSlot.startTime, "hh:mm aaaaa'm'") + " - " + format(shiftSlot.endTime, "hh:mm aaaaa'm'") : format(shiftSlot.startTime, "hh:mm aaaaa'm'") + " - " + format(shiftSlot.endTime, "hh:mm aaaaa'm'");
         return (
-          <MenuItem key={shiftSlot.id} value={nameAndTime}>{nameAndTime}</MenuItem>
+          <MenuItem key={shiftSlot.id} value={nameAndTime}>
+            <Checkbox checked={selectedShifts.includes(nameAndTime)} />
+            <ListItemText primary={nameAndTime} />
+          </MenuItem>
         )
     })))
     }
@@ -69,24 +82,29 @@ export const ShiftDetails = () => {
               <DatePicker defaultValue={dayjs()} slotProps={{textField: {size: "small"}}} sx={{width: 200}} />
             </LocalizationProvider>
             <h4 className="endtime-label">Select Shift(s): </h4>
-            <Box sx={{ minWidth: 120 }}>
-              <FormControl fullWidth>
-                <InputLabel id="demo-simple-select-label">Shift(s)</InputLabel>
-                <Select
-                  labelId="demo-simple-select-label"
-                  id="demo-simple-select"
-                  value={selectedShifts}
-                  label="Shift(s)"
-                  onChange={handleChange}
-                >
-                  {renderDropDown()}
-                </Select>
-              </FormControl>
-            </Box>
+            <FormControl sx={{ m: .5, width: 250}}>
+              <InputLabel id="shiftsCheckedDropDown" hidden={isEmergencyModalOpen||isStatusModalOpen||isVolunteerModalOpen}>Shift(s)</InputLabel>
+              <Select
+                labelId="shiftCheckboxLabel"
+                id="multiShiftCheckboxLabel"
+                multiple
+                value={selectedShifts}
+                onChange={handleChange}
+                input={<OutlinedInput label="Shift(s)" />}
+                renderValue={(selected) => selected.join(', ')}
+              >
+                {renderDropDown()}
+              </Select>
+            </FormControl>
           </div> 
         </div>
         <div className="shiftdetails-table">
-          <ShiftDetailsTable onSignUpVolunteersClick={onSignUpVolunteersClick} onSendEmergencyAlertClick={onSendEmergencyAlertClick} onStatusModalClick={onStatusModalClick}/>
+          <ShiftDetailsTable 
+            onSignUpVolunteersClick={onSignUpVolunteersClick} 
+            onSendEmergencyAlertClick={onSendEmergencyAlertClick} 
+            onStatusModalClick={onStatusModalClick}
+            stickyHeader={stickyHeader}
+            headerZIndex={headerZIndex}/>
         </div>
       </div>
     );

--- a/client_app/src/components/shelter/ShiftDetailsData.tsx
+++ b/client_app/src/components/shelter/ShiftDetailsData.tsx
@@ -2,10 +2,9 @@ export const shiftDetailsData = {
     data: [
       {
         id: 1,
-        date: "10/10/2024",
         name: "Morning",
-        startTime: "10:00 AM",
-        endTime: "2:00 PM",
+        startTime: 1728572400000,
+        endTime: 1728586800000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 2,
         desiredVolunteers: 8,
@@ -14,9 +13,8 @@ export const shiftDetailsData = {
       },
       {
         id: 2,
-        date: "10/10/2024",
-        startTime: "10:00 AM",
-        endTime: "2:00 PM",
+        startTime: 1728572400000,
+        endTime: 1728586800000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 6,
         desiredVolunteers: 8,
@@ -25,9 +23,8 @@ export const shiftDetailsData = {
       },
       {
         id: 3,
-        date: "10/10/2024",
-        startTime: "10:00 AM",
-        endTime: "2:00 PM",
+        startTime: 1728572400000,
+        endTime: 1728586800000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 3,
         desiredVolunteers: 4,
@@ -36,9 +33,8 @@ export const shiftDetailsData = {
       },
       {
         id: 4,
-        date: "10/10/2024",
-        startTime: "10:00 AM",
-        endTime: "2:00 PM",
+        startTime: 1728572400000,
+        endTime: 1728586800000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 6,
         desiredVolunteers: 8,
@@ -47,9 +43,8 @@ export const shiftDetailsData = {
       },
       {
         id: 5,
-        date: "10/10/2024",
-        startTime: "10:00 AM",
-        endTime: "2:00 PM",
+        startTime: 1728572400000,
+        endTime: 1728586800000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 6,
         desiredVolunteers: 8,
@@ -58,9 +53,8 @@ export const shiftDetailsData = {
       },
       {
         id: 6,
-        date: "10/10/2024",
-        startTime: "10:00 AM",
-        endTime: "2:00 PM",
+        startTime: 1728572400000,
+        endTime: 1728586800000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 6,
         desiredVolunteers: 8,
@@ -69,9 +63,8 @@ export const shiftDetailsData = {
       },
       {
         id: 7,
-        date: "10/10/2024",
-        startTime: "10:00 AM",
-        endTime: "2:00 PM",
+        startTime: 1728572400000,
+        endTime: 1728586800000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 6,
         desiredVolunteers: 8,
@@ -80,9 +73,8 @@ export const shiftDetailsData = {
       },
       {
         id: 8,
-        date: "10/10/2024",
-        startTime: "10:00 AM",
-        endTime: "2:00 PM",
+        startTime: 1728572400000,
+        endTime: 1728586800000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 6,
         desiredVolunteers: 8,
@@ -97,19 +89,19 @@ export const availableShifts = {
     {
       id: 1,
       name: "Morning",
-      startTime: "10:00 AM",
-      endTime: "12:00 PM"
+      startTime: 1728572400000,
+      endTime: 1728586800000,
     },
     {
       id: 2,
-      startTime: "12:00 PM",
-      endTime: "6:00 PM"
+      startTime: 1728586800000,
+      endTime: 1728601200000
     },
     {
       id: 3,
       name: "Evening",
-      startTime: "6:00 PM",
-      endTime: "12:00 AM"
+      startTime: 1728601200000,
+      endTime: 1728622800000
     }
   ]
 }

--- a/client_app/src/components/shelter/ShiftDetailsTable.js
+++ b/client_app/src/components/shelter/ShiftDetailsTable.js
@@ -6,10 +6,17 @@ import IconButton from "@mui/material/IconButton";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope, faCheck, faX, faPenToSquare, faTriangleExclamation} from '@fortawesome/free-solid-svg-icons';
 import { useNavigate } from "react-router-dom";
+import { format } from "date-fns";
 
 export const ShiftDetailsTable = props => {
   const navigate = useNavigate();
-  const { onSignUpVolunteersClick , onSendEmergencyAlertClick, onStatusModalClick} = props;
+  const { 
+    onSignUpVolunteersClick , 
+    onSendEmergencyAlertClick, 
+    onStatusModalClick,
+    stickyHeader,
+    headerZIndex,
+    } = props;
 
   const emailButton = () => {
     return (
@@ -89,7 +96,7 @@ export const ShiftDetailsTable = props => {
   return (
     <div className="shiftdetails-container">
       <table className="shiftsTable">
-        <thead className="shiftsTableHeader">
+        <thead className="shiftsTableHeader" style={{position:stickyHeader,zIndex:headerZIndex,top:-1}}>
           <tr>
             <th>Date</th>
             <th>Shift</th>
@@ -103,8 +110,8 @@ export const ShiftDetailsTable = props => {
         <tbody className="shiftsTableBody">
           {shiftDetailsData.data.map((shift) => (
             <tr key={shift.id}>
-              <td>{shift.date}</td>
-              <td>{shift.name ? shift.name + ": " + shift.startTime + ' - ' + shift.endTime : shift.startTime + ' - ' + shift.endTime}</td>
+              <td>{format(shift.startTime, "MM/dd/yyyy")}</td>
+              <td>{shift.name ? shift.name + ": " + format(shift.startTime, "hh:mm aaaaa'm'") + ' - ' + format(shift.endTime, "hh:mm aaaaa'm'") : format(shift.startTime, "hh:mm aaaaa'm'") + ' - ' + format(shift.endTime, "hh:mm aaaaa'm'")}</td>
               <td>{renderCoverage(shift)}</td>
               <td>{viewRosterButton()}</td>
               <td>{shift.status ? openStatusButton(shift) : closedStatusButton(shift)}</td>

--- a/client_app/src/components/shelter/ShiftsModal.js
+++ b/client_app/src/components/shelter/ShiftsModal.js
@@ -5,6 +5,7 @@ import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
 import "../../styles/shelter/ShiftsModal.css"
 import { ModalComponent } from './ModalComponent';
 import { ENVIROMENT } from '../../config.js';
+import { format } from "date-fns";
 
 export const ShiftsModal = props => {
   const {isVolunteerModalOpen, setIsVolunteerModalOpen} = props;
@@ -45,25 +46,33 @@ export const ShiftsModal = props => {
             Signed-Up Volunteers
           </h3>
         </span>
-        <p>{"Date: " + volunteerShifts.shift.date}</p>
-        <p>{"Shift: " + volunteerShifts.shift.name ?
-          volunteerShifts.shift.name + ": " + volunteerShifts.shift.startTime + " - " + volunteerShifts.shift.endTime 
-          : volunteerShifts.shift.startTime + " - " + volunteerShifts.shift.endTime}</p>
-        <p>{"Current Volunteer Count: " + volunteerShifts.shift.currentVolunteers}</p>
-        <p>{"Required Volunteer Count: " + volunteerShifts.shift.requiredVolunteers}</p>
-        <table className="shiftsTable">
-          <thead className="shiftsTableHeader">
-            <tr>
-              <th>Name</th>
-              <th>Phone Number</th>
-              <th>Email</th>
-              <th>Send E-mail</th>
-            </tr>
-          </thead>
-          <tbody className="shiftsTableBody">
-            {renderShifts()}
-          </tbody>
-        </table>
+        <div className="overallShiftDetails">
+          <div className="dateAndShiftInfo">
+            <p><b>Date: </b>{format(volunteerShifts.shift.startTime, "MM/dd/yyyy")}</p>
+            <p><b>Shift: </b>{volunteerShifts.shift.name ?
+            volunteerShifts.shift.name + ": " + format(volunteerShifts.shift.startTime, "hh:mm aaaaa'm'") + " - " + format(volunteerShifts.shift.endTime, "hh:mm aaaaa'm'") 
+            : format(volunteerShifts.shift.startTime, "hh:mm aaaaa'm'") + " - " + format(volunteerShifts.shift.endTime, "hh:mm aaaaa'm'")}</p>
+          </div>
+          <div className="volunteerCountInfo">
+            <p><b>Current Volunteer Count: </b>{volunteerShifts.shift.currentVolunteers}</p>
+            <p><b>Required Volunteer Count: </b>{volunteerShifts.shift.requiredVolunteers}</p>
+          </div>
+        </div>
+        <div className="shiftsTableContainer">
+          <table className="shiftsTable">
+            <thead className="shiftsTableHeader">
+              <tr>
+                <th>Name</th>
+                <th>Phone Number</th>
+                <th>Email</th>
+                <th>Send E-mail</th>
+              </tr>
+            </thead>
+            <tbody className="shiftsTableBody">
+              {renderShifts()}
+            </tbody>
+          </table>
+        </div>
       </div>
     ) 
   }

--- a/client_app/src/components/shelter/shiftsListed.tsx
+++ b/client_app/src/components/shelter/shiftsListed.tsx
@@ -1,9 +1,8 @@
 export const shiftListed = {
     shift: {
       "name": "Morning",
-      "date": "09/14/2024",
-      "startTime": "10:00 AM",
-      "endTime": "2:00 PM",
+      "startTime": 1728572400000,
+      "endTime": 1728586800000,
       "currentVolunteers": 3,
       "requiredVolunteers": 4,
     },

--- a/client_app/src/styles/shelter/Modal.css
+++ b/client_app/src/styles/shelter/Modal.css
@@ -1,7 +1,7 @@
 .modalComponent {
   max-height: 75%;
   max-width: 100%;
-  min-width: 80%;
+  min-width: 50%;
   min-height: 50%;
   background-color: lightgray;
   position: absolute;
@@ -10,7 +10,7 @@
   transform: translate(-50%, -50%);
   padding-left: 1%;
   padding-top: 1%;
-  padding-right: 1%
+  padding-right: 1%;
 }
 
 .close-btn {

--- a/client_app/src/styles/shelter/ShiftDetails.css
+++ b/client_app/src/styles/shelter/ShiftDetails.css
@@ -9,7 +9,6 @@
     display: flex;
     align-items: last baseline;
     justify-content: flex-start;
-    padding: 1.2vw;
     padding-left: 2vw;
     gap: 25px;
 }
@@ -23,7 +22,7 @@
 }
 
 .shiftdetails-table {
-    padding: 20px;
+    padding: 0px;
     margin-left: 10px;
 }
 
@@ -32,9 +31,8 @@
       width: 80%;
       flex-direction: column;
       align-items: center;
-      padding: 2vw;
       padding-left: 25vw;
-      gap: 5px;
+      gap: .5;
     }
   
     .starttime-label, .endtime-label {
@@ -48,14 +46,13 @@
     width: 100%;
     flex-direction: row;
     align-items: center;
-    padding: 2vw;
-    gap: 5px;
+    gap: .5;
 }
 .date-label {
     font-size: 15px;
 }
 
-.starttime-label, .endtime-label {
+.starttime-label, .endtime-label, .multiShiftCheckboxLabel {
     padding-left: 10px;
     margin-bottom: 10px;
     font-size: 15px;
@@ -67,7 +64,6 @@
         flex-direction: row;
         align-items: center;
         justify-content: center;
-        padding: 2vw;
-        gap: 5px;
+        gap: .5;
     }
 }

--- a/client_app/src/styles/shelter/ShiftDetailsTable.css
+++ b/client_app/src/styles/shelter/ShiftDetailsTable.css
@@ -3,11 +3,12 @@
     flex-direction: column;
     border-radius: 10px;
     padding: 30px;
-    padding-top: 10px;
+    padding-top: 0px;
     padding-bottom: 10px;
     background-color: #f2f3f4; 
     box-shadow: #fff; 
     overflow-y: auto;
+    overflow-x: auto;
 }
 
 .editButton { 
@@ -59,15 +60,14 @@
 
 table {
   width: 100%;
+  overflow-x: auto;
+  white-space: nowrap;
+  min-width: fit-content;
+  padding-top: 0px;
 }
-thead, tbody tr {
-  display: table;
-  width: 100%;
-  table-layout: fixed;
-}
+
 tbody {
-  display: block;
   overflow-y: auto;
-  table-layout: fixed;
   max-height: 60vh;
+  min-width: fit-content;
 }

--- a/client_app/src/styles/shelter/ShiftsModal.css
+++ b/client_app/src/styles/shelter/ShiftsModal.css
@@ -17,6 +17,7 @@
 .shiftsTable {
   background-color: white;
   border-collapse: collapse;
+  width: 100%;
 }
 
 td, th, tr{
@@ -26,5 +27,19 @@ td, th, tr{
 
 .modalHeading {
   display: inline-block;
-  padding-bottom: 3%;
+}
+
+.shiftsTableContainer {
+  overflow-x: auto;
+}
+
+.overallShiftDetails {
+  margin-bottom: 2%;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.volunteerCountInfo {
+  justify-self: end;
 }

--- a/client_app/src/styles/shelter/confirmStatusModal.css
+++ b/client_app/src/styles/shelter/confirmStatusModal.css
@@ -1,0 +1,22 @@
+.yesStatusButton, .noStatusButton {
+  border-radius: 5px;
+}
+
+.yesStatusButton {
+  background-color: red;
+  margin-right: 40%;
+}
+
+.buttonContainer {
+  text-align: center;
+  position: absolute;
+  top: 65%;
+  width: 100%
+}
+
+.confirmationMessage {
+  margin-top: 10%;
+  margin-left: 5%;
+  margin-right: 5%;
+  text-align: center;
+}

--- a/client_app/src/styles/shelter/emergencyAlertModal.css
+++ b/client_app/src/styles/shelter/emergencyAlertModal.css
@@ -1,0 +1,21 @@
+.emergencyMessage {
+  background-color: white;
+  height: 30vh;
+  width: 70vw;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+
+.sendButton {
+  border-radius: 5px;
+  margin-top: 2%;
+  margin-bottom: 3%;
+  float: right;
+}
+
+.sendButtonContainer {
+  width: 100%;
+  margin-right: 10%;
+  margin-bottom: 3%;
+}


### PR DESCRIPTION
Fixes #137 

**What was changed?**
Changed the styling of the shift details page to the Figma link as well as how the date and time values were constructed.

**Why was it changed?**
The code before was not responsive to mobile sizing and did not have all of the details from the Figma implemented (just the outline of all of the components and their data). Also the time is now converted from UNIX EPOCH time in ms using date-fns format method (like on the volunteer side of the application) to reduce the amount of changes required when the backend is implemented. 

**How was it changed?**
Modified EmergencyAlertModal, ConfirmStatusChangeModal, ShiftsModal, ShiftDetails, and ShiftDetailsTable and added a styling file or altered their pre-existing style file (corresponding to their names). 

**Important changes:** 
In ShiftDetailsTable the dynamic rendering of the header on the base shift details page, otherwise the header appears over the Modal. 

I did not implement the sticky columns because as you can see in the design otherwise the 2 first columns essentially take over the entire computer screen however, you can hover/click on a row and it changes colors (easier for the user to track which row they were on). We can ask our client but I assume staff would typically be viewing this information from a computer or ipad rather than a phone. 


**Screenshots that show the changes (if applicable):**
<img width="1440" alt="Screenshot 2024-10-27 at 1 09 06 PM" src="https://github.com/user-attachments/assets/9531f5aa-346b-4536-bf6d-364dbe73c1fc">
<img width="1424" alt="Screenshot 2024-10-27 at 1 09 15 PM" src="https://github.com/user-attachments/assets/f80eb455-c589-4e68-b709-e3b072ab9964">
<img width="1414" alt="Screenshot 2024-10-27 at 1 09 22 PM" src="https://github.com/user-attachments/assets/02156b9d-39df-4827-8e83-b23aa495389c">
<img width="690" alt="Screenshot 2024-10-27 at 1 09 28 PM" src="https://github.com/user-attachments/assets/d772c0fc-6ac0-4e70-a468-c77faa000243">
<img width="1414" alt="Screenshot 2024-10-27 at 1 09 33 PM" src="https://github.com/user-attachments/assets/a76e25e1-7d69-4b59-bcf7-3ba873431d75">
<img width="1166" alt="Screenshot 2024-10-27 at 1 09 38 PM" src="https://github.com/user-attachments/assets/8bc761d8-3a3c-4cdd-b53d-daaecb82522d">
<img width="209" alt="Screenshot 2024-10-27 at 1 11 30 PM" src="https://github.com/user-attachments/assets/b8aff5d9-64bf-4828-9ff2-187383dd3f55">
<img width="188" alt="Screenshot 2024-10-27 at 1 11 36 PM" src="https://github.com/user-attachments/assets/9abf0122-9867-4dd3-929c-9b2f8264b6d3">
<img width="192" alt="Screenshot 2024-10-27 at 1 11 42 PM" src="https://github.com/user-attachments/assets/f2b1c2df-05fb-41e8-b8f0-e665b53dbf32">
<img width="192" alt="Screenshot 2024-10-27 at 1 11 48 PM" src="https://github.com/user-attachments/assets/1e19d563-428c-498e-988d-f3549860b5c6">

