### PR TITLE
Shelter Dashboard: Update 'Contact Past Volunteers' Feature to Include 'View All' Functionality (#143) fixed

### DIFF
--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -1,6 +1,5 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { PastShifts, UpcomingShifts } from "./components/volunteer/Shifts";
-//import { PastShifts } from "./components/volunteer/Shifts";
 import Shelters from "./components/volunteer/Shelters";
 import VolunteerDashboard from "./components/volunteer/VolunteerDashboard";
 import NavBarVolunteerDashboard from "./components/volunteer/NavBarVolunteerDashboard";

--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -13,6 +13,7 @@ import ShelterDashboard from "./components/shelter/ShelterDashboard";
 import RequestForHelp from "./components/shelter/RequestForHelp";
 import { ShiftDetails } from "./components/shelter/ShiftDetails";
 import UpcomingRequests from "./components/shelter/UpcomingRequests";
+import AllVolunteers from "./components/shelter/AllVolunteers";
 import "./styles/App.css";
 
 function App() {
@@ -20,7 +21,7 @@ function App() {
   return (
     <>
       <Router>
-        {["/shelter-dashboard", "/shift-details", "/request-for-help", "/cancel-shifts", "/upcoming-requests"].includes(
+        {["/shelter-dashboard", "/shift-details", "/request-for-help", "/upcoming-requests", "/past-volunteers"].includes(
           window.location.pathname,
         ) ? (
           <NavBarShelterDashboard auth={auth} />
@@ -41,6 +42,7 @@ function App() {
             <Route path="/shelter-dashboard" element={<ShelterDashboard />} />
             <Route path="/shift-details" element={<ShiftDetails />} />
             <Route path="/request-for-help" element={<RequestForHelp />} />
+            <Route path="/past-volunteers" element={<AllVolunteers />} />
           </Route>
         </Routes>
       </Router>

--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -13,7 +13,6 @@ import ShelterDashboard from "./components/shelter/ShelterDashboard";
 import RequestForHelp from "./components/shelter/RequestForHelp";
 import { ShiftDetails } from "./components/shelter/ShiftDetails";
 import UpcomingRequests from "./components/shelter/UpcomingRequests";
-import AllVolunteers from "./components/shelter/AllVolunteers";
 import "./styles/App.css";
 
 function App() {
@@ -21,7 +20,7 @@ function App() {
   return (
     <>
       <Router>
-        {["/shelter-dashboard", "/shift-details", "/request-for-help", "/upcoming-requests", "/past-volunteers"].includes(
+        {["/shelter-dashboard", "/shift-details", "/request-for-help", "/upcoming-requests"].includes(
           window.location.pathname,
         ) ? (
           <NavBarShelterDashboard auth={auth} />
@@ -42,7 +41,6 @@ function App() {
             <Route path="/shelter-dashboard" element={<ShelterDashboard />} />
             <Route path="/shift-details" element={<ShiftDetails />} />
             <Route path="/request-for-help" element={<RequestForHelp />} />
-            <Route path="/past-volunteers" element={<AllVolunteers />} />
           </Route>
         </Routes>
       </Router>

--- a/client_app/src/components/shelter/AllVolunteers.js
+++ b/client_app/src/components/shelter/AllVolunteers.js
@@ -1,28 +1,13 @@
 import "../../styles/index.css";
+import ProcessVolunteerList from "./ProcessVolunteerList";
 const AllVolunteers = ({shiftDetails}) => {
     return (
       <>
-        <div className="conf-page">
-          <h1>Past Volunteers</h1>
-          <table>
-            <thead>
-              <tr>
-                <th>
-                  <h2>#</h2>
-                </th>
-                <th>
-                  <h2>Volunteer Name</h2>
-                </th>
-                <th>
-                  <h2>Volunteer Email</h2>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-                
-            </tbody>
-          </table>
+        {shiftDetails &&  (
+        <div>
+          <ProcessVolunteerList shiftDetails={shiftDetails} />
         </div>
+      )}
       </>
     );
 }

--- a/client_app/src/components/shelter/AllVolunteers.js
+++ b/client_app/src/components/shelter/AllVolunteers.js
@@ -1,0 +1,9 @@
+import "../../styles/shelter/PastVolunteers.css";
+
+const AllVolunteers = ({shiftDetails}) => {
+    return (
+      <div>Hi</div>
+    );
+}
+
+export default AllVolunteers;

--- a/client_app/src/components/shelter/AllVolunteers.js
+++ b/client_app/src/components/shelter/AllVolunteers.js
@@ -1,8 +1,29 @@
-import "../../styles/shelter/PastVolunteers.css";
-
+import "../../styles/index.css";
 const AllVolunteers = ({shiftDetails}) => {
     return (
-      <div>Hi</div>
+      <>
+        <div className="conf-page">
+          <h1>Past Volunteers</h1>
+          <table>
+            <thead>
+              <tr>
+                <th>
+                  <h2>#</h2>
+                </th>
+                <th>
+                  <h2>Volunteer Name</h2>
+                </th>
+                <th>
+                  <h2>Volunteer Email</h2>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+                
+            </tbody>
+          </table>
+        </div>
+      </>
     );
 }
 

--- a/client_app/src/components/shelter/AllVolunteers.js
+++ b/client_app/src/components/shelter/AllVolunteers.js
@@ -1,5 +1,5 @@
-import "../../styles/index.css";
 import ProcessVolunteerList from "./ProcessVolunteerList";
+
 const AllVolunteers = ({shiftDetails}) => {
     return (
       <>

--- a/client_app/src/components/shelter/ProcessVolunteerList.js
+++ b/client_app/src/components/shelter/ProcessVolunteerList.js
@@ -1,9 +1,12 @@
+import { Link } from "react-router-dom";
+
+const handleReload = () => {
+  window.location.reload();
+};
+
 const ProcessVolunteerList = ({shiftDetails}) => {
     const currentTime = Date.now();
     const filteredShifts = shiftDetails.filter(item => item.start_time < currentTime);
-    // const workerList = filteredShifts
-    // .flatMap(item => item.worker ? item.worker.split(",").map(name => name.trim()) : []);
-    // const uniqueWorker = [...new Set(workerList)];
     const workerList = filteredShifts.flatMap(item => {
         const workers = item.worker ? item.worker.split(",").map(name => name.trim()) : [];
         const emails = item.email ? item.email.split(",").map(email => email.trim()) : [];
@@ -26,18 +29,18 @@ const ProcessVolunteerList = ({shiftDetails}) => {
             <thead>
               <tr>
                 <th>
-                  <h2>#</h2>
+                  <h3>#</h3>
                 </th>
                 <th>
-                  <h2>Volunteer Name</h2>
+                  <h3>Volunteer Name</h3>
                 </th>
                 <th>
-                  <h2>Volunteer Email</h2>
+                  <h3>Volunteer Email</h3>
                 </th>
               </tr>
             </thead>
             <tbody>
-              {uniqueWorkerList.map((list, index) => (
+              {uniqueWorkerList.length > 0 ? (uniqueWorkerList.map((list, index) => (
                 <tr key={index}>
                   <td>
                     <p>{index+1}</p>
@@ -46,12 +49,25 @@ const ProcessVolunteerList = ({shiftDetails}) => {
                     <p>{list.worker}</p>
                   </td>
                   <td>
-                    <p>{list.email}</p>
+                    <a href={`mailto:${list.email}`}>
+                      <p>{list.email}</p>
+                    </a>
                   </td>
                 </tr>
-              ))}
+              ))
+              ) : (
+                <tr>
+                  <td colSpan="100%" style={{textAlign: "center"}}>No volunteers available.</td>
+                </tr>
+             )}
             </tbody>
           </table>
+          <br />
+          <div className="button-row">
+            <Link to="/shelter-dashboard" onClick={handleReload}>
+              <button>Your Dashboard</button>
+            </Link>
+          </div>
         </div>
       </>
     );

--- a/client_app/src/components/shelter/ProcessVolunteerList.js
+++ b/client_app/src/components/shelter/ProcessVolunteerList.js
@@ -1,0 +1,44 @@
+const ProcessVolunteerList = ({shiftDetails}) => {
+    const currentTime = Date.now();
+    const filteredShifts = shiftDetails.filter(item => item.start_time < currentTime);
+    const workerList = filteredShifts
+    .flatMap(item => item.worker ? item.worker.split(",").map(name => name.trim()) : []);
+    const uniqueWorker = [...new Set(workerList)];
+
+    return (
+      <>
+        <div className="conf-page">
+          <h1>Past Volunteers</h1>
+          <table>
+            <thead>
+              <tr>
+                <th>
+                  <h2>#</h2>
+                </th>
+                <th>
+                  <h2>Volunteer Name</h2>
+                </th>
+                <th>
+                  <h2>Volunteer Email</h2>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {uniqueWorker.map((worker, index) => (
+                <tr key={index}>
+                  <td>
+                    <p>{index+1}</p>
+                  </td>
+                  <td>
+                    <p>{worker}</p>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </>
+    );
+}
+
+export default ProcessVolunteerList;

--- a/client_app/src/components/shelter/ProcessVolunteerList.js
+++ b/client_app/src/components/shelter/ProcessVolunteerList.js
@@ -1,9 +1,22 @@
 const ProcessVolunteerList = ({shiftDetails}) => {
     const currentTime = Date.now();
     const filteredShifts = shiftDetails.filter(item => item.start_time < currentTime);
-    const workerList = filteredShifts
-    .flatMap(item => item.worker ? item.worker.split(",").map(name => name.trim()) : []);
-    const uniqueWorker = [...new Set(workerList)];
+    // const workerList = filteredShifts
+    // .flatMap(item => item.worker ? item.worker.split(",").map(name => name.trim()) : []);
+    // const uniqueWorker = [...new Set(workerList)];
+    const workerList = filteredShifts.flatMap(item => {
+        const workers = item.worker ? item.worker.split(",").map(name => name.trim()) : [];
+        const emails = item.email ? item.email.split(",").map(email => email.trim()) : [];
+        
+        return workers.map((name, index) => ({
+          worker: name,
+          email: emails[index]
+        }));
+    });
+
+    const uniqueWorkerList = workerList.filter((entry, index, self) =>
+        index === self.findIndex(e => e.worker === entry.worker && e.email === entry.email)
+    );
 
     return (
       <>
@@ -24,13 +37,16 @@ const ProcessVolunteerList = ({shiftDetails}) => {
               </tr>
             </thead>
             <tbody>
-              {uniqueWorker.map((worker, index) => (
+              {uniqueWorkerList.map((list, index) => (
                 <tr key={index}>
                   <td>
                     <p>{index+1}</p>
                   </td>
                   <td>
-                    <p>{worker}</p>
+                    <p>{list.worker}</p>
+                  </td>
+                  <td>
+                    <p>{list.email}</p>
                   </td>
                 </tr>
               ))}

--- a/client_app/src/components/shelter/ProcessVolunteerList.js
+++ b/client_app/src/components/shelter/ProcessVolunteerList.js
@@ -21,47 +21,52 @@ const ProcessVolunteerList = ({shiftDetails}) => {
         index === self.findIndex(e => e.worker === entry.worker && e.email === entry.email)
     );
 
+    const renderVolunteerTable = () => (
+      <table>
+        <thead>
+          <tr>
+            <th>
+              <h3>#</h3>
+            </th>
+            <th>
+              <h3>Volunteer Name</h3>
+            </th>
+            <th>
+              <h3>Volunteer Email</h3>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {uniqueWorkerList.map((list, index) => (
+            <tr key={index}>
+              <td>
+                <p>{index + 1}</p>
+              </td>
+              <td>
+                <p>{list.worker}</p>
+              </td>
+              <td>
+                <a href={`mailto:${list.email}`}>
+                  <p>{list.email}</p>
+                </a>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+
     return (
       <>
         <div className="conf-page">
           <h1>Past Volunteers</h1>
-          <table>
-            <thead>
-              <tr>
-                <th>
-                  <h3>#</h3>
-                </th>
-                <th>
-                  <h3>Volunteer Name</h3>
-                </th>
-                <th>
-                  <h3>Volunteer Email</h3>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {uniqueWorkerList.length > 0 ? (uniqueWorkerList.map((list, index) => (
-                <tr key={index}>
-                  <td>
-                    <p>{index+1}</p>
-                  </td>
-                  <td>
-                    <p>{list.worker}</p>
-                  </td>
-                  <td>
-                    <a href={`mailto:${list.email}`}>
-                      <p>{list.email}</p>
-                    </a>
-                  </td>
-                </tr>
-              ))
-              ) : (
-                <tr>
-                  <td colSpan="100%" style={{textAlign: "center"}}>No volunteers available.</td>
-                </tr>
-             )}
-            </tbody>
-          </table>
+          {(!uniqueWorkerList || uniqueWorkerList.length === 0) ? (
+            <div>
+              <span>No past volunteers available.</span>
+            </div>
+          ) : (
+            renderVolunteerTable()
+          )}
           <br />
           <div className="button-row">
             <Link to="/shelter-dashboard" onClick={handleReload}>

--- a/client_app/src/components/shelter/ShelterDashboard.js
+++ b/client_app/src/components/shelter/ShelterDashboard.js
@@ -66,33 +66,36 @@ function ShelterDashboard() {
     <div>
       <div className="shelter-dashboard">
         <div className="container-large">
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              width: "98%",
-            }}>
+          <div className="container-align">
             <h4>Open requests</h4>
             <a href="/shift-details">View all</a>
           </div>
           <OpenRequest />
         </div>
         <div className="container-medium">
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              width: "98%",
-            }}>
+          <div className="container-align">
             <h4>Today's Roster</h4>
             <a href="/shift-details">View all</a>
           </div>
           <ShiftContainer shiftDetails={shiftDetails} />
         </div>
         <div className="container-small">
-          <h4>Contact Past Volunteers</h4>
+          <div className="container-align">
+            <h4>Contact Past Volunteers</h4>
+            <button
+              style={{
+                backgroundColor: "#f9f6f6",
+                border: "none",
+                outline: "none",
+                color: "#0066b2",
+                fontSize: "1.0rem",
+                textDecoration: "underline",
+                textAlign: "center",
+                padding: "0"
+              }}>
+              View all
+            </button>
+          </div>
           <PastVolunteersContainer shiftDetails={shiftDetails} />
         </div>
       </div>

--- a/client_app/src/components/shelter/ShelterDashboard.js
+++ b/client_app/src/components/shelter/ShelterDashboard.js
@@ -1,6 +1,7 @@
 import React from "react";
 import OpenRequest from "./OpenRequests";
 import PastVolunteersContainer from "./PastVolunteersContainer";
+import PastVolunteers from "./PastVolunteers";
 import ShiftContainer from "./ShiftContainer";
 import "../../styles/index.css";
 import { useState, useRef, useEffect } from "react";
@@ -13,6 +14,7 @@ import { SERVER } from "../../config";
 
 function ShelterDashboard() {
   const [shiftDetails, setShiftDetails] = useState([]);
+  const [showPastVolunteers, setShowPastVolunteers] = useState(false);
   let shelterId = 30207;
   let startTime = 
       setHours(
@@ -82,19 +84,7 @@ function ShelterDashboard() {
         <div className="container-small">
           <div className="container-align">
             <h4>Contact Past Volunteers</h4>
-            <button
-              style={{
-                backgroundColor: "#f9f6f6",
-                border: "none",
-                outline: "none",
-                color: "#0066b2",
-                fontSize: "1.0rem",
-                textDecoration: "underline",
-                textAlign: "center",
-                padding: "0"
-              }}>
-              View all
-            </button>
+            <a href="/past-volunteers">View all</a>
           </div>
           <PastVolunteersContainer shiftDetails={shiftDetails} />
         </div>

--- a/client_app/src/components/shelter/ShelterDashboard.js
+++ b/client_app/src/components/shelter/ShelterDashboard.js
@@ -89,11 +89,12 @@ function ShelterDashboard() {
                   backgroundColor: "#f9f6f6",
                   border: "none",
                   outline: "none",
-                  color: "#0066b2",
+                  color: "#1F75FE",
                   fontSize: "1.0rem",
                   textDecoration: "underline",
                   textAlign: "center",
-                  padding: "0"
+                  padding: "0",
+                  marginTop: "-5px"
                 }}
                 onClick={() => setShowAllPastVolunteers(true)}
                 >

--- a/client_app/src/components/shelter/ShelterDashboard.js
+++ b/client_app/src/components/shelter/ShelterDashboard.js
@@ -1,7 +1,6 @@
 import React from "react";
 import OpenRequest from "./OpenRequests";
 import PastVolunteersContainer from "./PastVolunteersContainer";
-import PastVolunteers from "./PastVolunteers";
 import ShiftContainer from "./ShiftContainer";
 import "../../styles/index.css";
 import { useState, useRef, useEffect } from "react";
@@ -10,11 +9,11 @@ import setMinutes from "date-fns/setMinutes";
 import setSeconds from "date-fns/setSeconds";
 import setMilliseconds from "date-fns/setMilliseconds";
 import { SERVER } from "../../config";
-
+import AllVolunteers from "./AllVolunteers";
 
 function ShelterDashboard() {
   const [shiftDetails, setShiftDetails] = useState([]);
-  const [showPastVolunteers, setShowPastVolunteers] = useState(false);
+  const [showAllPastVolunteers, setShowAllPastVolunteers] = useState(false);
   let shelterId = 30207;
   let startTime = 
       setHours(
@@ -66,6 +65,7 @@ function ShelterDashboard() {
 
   return (
     <div>
+      {!showAllPastVolunteers && (
       <div className="shelter-dashboard">
         <div className="container-large">
           <div className="container-align">
@@ -84,11 +84,31 @@ function ShelterDashboard() {
         <div className="container-small">
           <div className="container-align">
             <h4>Contact Past Volunteers</h4>
-            <a href="/past-volunteers">View all</a>
+            <button
+              style={{
+                backgroundColor: "#f9f6f6",
+                border: "none",
+                outline: "none",
+                color: "#0066b2",
+                fontSize: "1.0rem",
+                textDecoration: "underline",
+                textAlign: "center",
+                padding: "0"
+              }}
+              onClick={() => setShowAllPastVolunteers(true)}
+              >
+              View all
+            </button>
           </div>
           <PastVolunteersContainer shiftDetails={shiftDetails} />
         </div>
       </div>
+      )}
+      {showAllPastVolunteers && (
+        <div>
+          <AllVolunteers shiftDetails={shiftDetails} />
+        </div>
+      )}
     </div>
   );
 }

--- a/client_app/src/components/shelter/ShelterDashboard.js
+++ b/client_app/src/components/shelter/ShelterDashboard.js
@@ -66,43 +66,43 @@ function ShelterDashboard() {
   return (
     <div>
       {!showAllPastVolunteers && (
-      <div className="shelter-dashboard">
-        <div className="container-large">
-          <div className="container-align">
-            <h4>Open requests</h4>
-            <a href="/shift-details">View all</a>
+        <div className="shelter-dashboard">
+          <div className="container-large">
+            <div className="container-align">
+              <h4>Open requests</h4>
+              <a href="/shift-details">View all</a>
+            </div>
+            <OpenRequest />
           </div>
-          <OpenRequest />
-        </div>
-        <div className="container-medium">
-          <div className="container-align">
-            <h4>Today's Roster</h4>
-            <a href="/shift-details">View all</a>
+          <div className="container-medium">
+            <div className="container-align">
+              <h4>Today's Roster</h4>
+              <a href="/shift-details">View all</a>
+            </div>
+            <ShiftContainer shiftDetails={shiftDetails} />
           </div>
-          <ShiftContainer shiftDetails={shiftDetails} />
-        </div>
-        <div className="container-small">
-          <div className="container-align">
-            <h4>Contact Past Volunteers</h4>
-            <button
-              style={{
-                backgroundColor: "#f9f6f6",
-                border: "none",
-                outline: "none",
-                color: "#0066b2",
-                fontSize: "1.0rem",
-                textDecoration: "underline",
-                textAlign: "center",
-                padding: "0"
-              }}
-              onClick={() => setShowAllPastVolunteers(true)}
-              >
-              View all
-            </button>
+          <div className="container-small">
+            <div className="container-align">
+              <h4>Contact Past Volunteers</h4>
+              <button
+                style={{
+                  backgroundColor: "#f9f6f6",
+                  border: "none",
+                  outline: "none",
+                  color: "#0066b2",
+                  fontSize: "1.0rem",
+                  textDecoration: "underline",
+                  textAlign: "center",
+                  padding: "0"
+                }}
+                onClick={() => setShowAllPastVolunteers(true)}
+                >
+                View all
+              </button>
+            </div>
+            <PastVolunteersContainer shiftDetails={shiftDetails} />
           </div>
-          <PastVolunteersContainer shiftDetails={shiftDetails} />
         </div>
-      </div>
       )}
       {showAllPastVolunteers && (
         <div>

--- a/client_app/src/styles/index.css
+++ b/client_app/src/styles/index.css
@@ -326,6 +326,18 @@ button {
   cursor: pointer;
 }
 
+.current-volunteer-count {
+  background-color: #ecececfc;
+  border: none;
+  outline: none;
+  color: #0066b2;
+  font-size: 0.9rem;
+  text-decoration: underline;
+  text-align: center;
+  padding-left: 0;
+  padding-right: 0;
+}
+
 @media screen and (max-width: 960px) {
   .volunteer-dashboard {
     display: block;

--- a/client_app/src/styles/index.css
+++ b/client_app/src/styles/index.css
@@ -326,18 +326,6 @@ button {
   cursor: pointer;
 }
 
-.current-volunteer-count {
-  background-color: #ecececfc;
-  border: none;
-  outline: none;
-  color: #0066b2;
-  font-size: 0.9rem;
-  text-decoration: underline;
-  text-align: center;
-  padding-left: 0;
-  padding-right: 0;
-}
-
 @media screen and (max-width: 960px) {
   .volunteer-dashboard {
     display: block;
@@ -396,6 +384,13 @@ button {
 .shift-container {
   width: 95%;
   margin-right: 15px;
+}
+
+.container-align {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 98%;
 }
 
 .shelter-dashboard .shift-card,

--- a/server/domains/volunteer.py
+++ b/server/domains/volunteer.py
@@ -12,6 +12,7 @@ class Volunteer:
     end_time: int
     count: int
     worker: str
+    email: str
 
     @classmethod
     def from_dict(self, d):

--- a/server/serializers/volunteer.py
+++ b/server/serializers/volunteer.py
@@ -13,6 +13,7 @@ class VolunteerJsonEncoder(json.JSONEncoder):
                 "end_time": volunteer.end_time,
                 "count": volunteer.count,
                 "worker": volunteer.worker,
+                "email": volunteer.email
             }
             return to_serialize
         except AttributeError:

--- a/server/use_cases/get_volunteers.py
+++ b/server/use_cases/get_volunteers.py
@@ -77,6 +77,7 @@ def get_volunteers_use_case(repo, request, shelter):
                 found = True
                 staff.count+=worker.count
                 staff.worker+=", "+worker.worker
+                staff.email+=", "+worker.email
                 # if worker and staff have different end time, we know
                 # that worker end time must be after staff end time
                 # as shown in case 2 comment. This is because all workers
@@ -90,7 +91,8 @@ def get_volunteers_use_case(repo, request, shelter):
                                         "start_time":staff.end_time, 
                                         "end_time":worker.end_time,
                                         "count":worker.count,
-                                        "worker":worker.worker
+                                        "worker":worker.worker,
+                                        "email":worker.email
                                     }))
             # since all staff were sorted by start time, then end time,
             # we know that worker start time cannot be before staff start time
@@ -105,13 +107,15 @@ def get_volunteers_use_case(repo, request, shelter):
                     {"start_time":worker.start_time,
                      "end_time":worker.end_time,
                      "count":staff.count+worker.count,
-                     "worker":staff.worker+", "+worker.worker})
+                     "worker":staff.worker+", "+worker.worker,
+                     "email":staff.email+", "+worker.email})
 
                 insert_staff2 = Volunteer.from_dict(
                                     {"start_time":worker.end_time,
                                      "end_time":staff.end_time,
                                      "count":staff.count,
-                                     "worker":staff.worker}
+                                     "worker":staff.worker,
+                                     "email":staff.email}
                                 )
                 staff.end_time = worker.start_time
                 workers.append(insert_staff1)
@@ -137,7 +141,8 @@ def get_volunteers_use_case(repo, request, shelter):
                                     {"start_time":worker.start_time,
                                      "end_time":staff.end_time,
                                      "count":staff.count+worker.count,
-                                     "worker":staff.worker+", "+worker.worker})
+                                     "worker":staff.worker+", "+worker.worker,
+                                     "email":staff.email+", "+worker.email})
                               )
 
                 if not worker.end_time == staff.end_time:
@@ -145,7 +150,8 @@ def get_volunteers_use_case(repo, request, shelter):
                                     {"start_time":staff.end_time,
                                      "end_time":worker.end_time,
                                      "count":worker.count,
-                                     "worker":worker.worker}
+                                     "worker":worker.worker,
+                                     "email":worker.email}
                                    ))
                 staff.end_time = worker.start_time
             if found:
@@ -173,6 +179,7 @@ def make_staffing_from_shifts(shifts):
                                              "end_time":shift.end_time,
                                              "count":1,
                                              "worker":shift.first_name + " "
-                                             + shift.last_name}))
+                                             + shift.last_name,
+                                             "email":shift.worker}))
     return workers
 


### PR DESCRIPTION
Fixes #143 

**What was changed?**

I changed the Shelter Dashboard.

**Why was it changed?**

It was changed so that when the user clicked on View all in the Contact Past Volunteers component, a list of past volunteers were displayed in a table. 

**How was it changed?**

I added two files, which processed the list of volunteers and displayed the data in the table. I added the email field to the Volunteer object, which is used by the get_volunteers API. To get the final list, I extracted the worker and email fields from the API, pair the worker with their email and remove duplicates. 

**Screenshots that show the changes (if applicable):**
<img width="356" alt="Screenshot 2024-11-09 at 1 14 30 PM" src="https://github.com/user-attachments/assets/be99c986-a689-40ba-83ee-521d27167282">
![novolunteers](https://github.com/user-attachments/assets/5392d666-954a-456f-8ee1-199a956aabb9)
<img width="1440" alt="Screenshot 2024-11-09 at 1 14 42 PM" src="https://github.com/user-attachments/assets/208cdd8d-064e-48d9-8152-0acb28e3cebf">
<img width="722" alt="Screenshot 2024-11-09 at 1 15 44 PM" src="https://github.com/user-attachments/assets/0b368671-7338-4441-993c-352aed5099e7">



