### PR TITLE
Fixed: Update Shift Details Page for Mobile View Enhancements and Date Grouping (Issue #142)

### DIFF
--- a/client_app/src/components/shelter/CancelRequestModal.js
+++ b/client_app/src/components/shelter/CancelRequestModal.js
@@ -17,8 +17,8 @@ export const CancelRequestModal = ({ isOpen, onClose, shift, onConfirmCancel }) 
         <h3>Confirm Cancellation</h3>
         <p className="message-text">Are you sure you want to cancel the shift scheduled on {shift.date} from {shift.fromTime} to {shift.toTime}?</p>
         <div className="button-container">
-          <button onClick={handleConfirm}>Yes, Cancel</button>
-          <button onClick={onClose}>No, Keep</button>
+          <button className="confirmationButton" onClick={handleConfirm}>Yes, Cancel</button>
+          <button className="cancellationButton" onClick={onClose}>No, Keep</button>
         </div>
       </div>
     );

--- a/client_app/src/components/shelter/ContactVolunteersModal.js
+++ b/client_app/src/components/shelter/ContactVolunteersModal.js
@@ -1,18 +1,18 @@
 import React, {useState} from 'react'; 
 import { ModalComponent } from './ModalComponent';
 import { ENVIROMENT } from '../../config.js';
-import "../../styles/shelter/emergencyAlertModal.css"
+import "../../styles/shelter/ContactVolunteersModal.css"
 
-export const EmergencyAlertModal = props => {
-  const {isEmergencyModalOpen, setIsEmergencyModalOpen} = props;
+export const ContactVolunteersModal = props => {
+  const {isContactVolunteersModalOpen, setIsContactVolunteersModalOpen} = props;
   const [containsMessage, setContainsMessage] = useState(false)
   const [input, setInput] = useState("");
 
-  const sendAlert = () => {
+  const sendMessage = () => {
     if (ENVIROMENT === "development") {
       console.log(input); //Todo
     }
-    setIsEmergencyModalOpen(false);
+    setIsContactVolunteersModalOpen(false);
   }
 
   const handleChange = (value) => {
@@ -29,19 +29,19 @@ export const EmergencyAlertModal = props => {
       <div>
         <span className="modalHeading">
           <h3>
-            Emergency Alert
+            Contact Volunteers
           </h3>
         </span>
-        <div className="emergencyMessageContainer">
+        <div className="volunteerMessageContainer">
           <textarea
               type="text"
               value={input}
               onChange={(e) => handleChange(e.target.value)}
-              className="emergencyMessage"
+              className="volunteerMessage"
           />
         </div>
         <div className="sendButtonContainer">
-          <button className="sendButton" disabled={!containsMessage} onClick={() => sendAlert()}>
+          <button className="sendButton" disabled={!containsMessage} onClick={() => sendMessage()}>
             Send
           </button>
         </div>
@@ -51,8 +51,8 @@ export const EmergencyAlertModal = props => {
 
   return (
     <ModalComponent
-      isOpen={isEmergencyModalOpen}
-      onRequestClose={() => setIsEmergencyModalOpen(false)}
+      isOpen={isContactVolunteersModalOpen}
+      onRequestClose={() => setIsContactVolunteersModalOpen(false)}
       renderData={renderData}
     /> 
   )

--- a/client_app/src/components/shelter/EditRequestModal.js
+++ b/client_app/src/components/shelter/EditRequestModal.js
@@ -23,18 +23,19 @@ export const EditRequestModal = ({ isOpen, onClose, shift, onSave }) => {
   };
 
   const renderData = () => (
-    <div>
-      <h3>Edit Shift</h3>
-      <label>
+    <div className="modalEditRequest">
+      <h3 className="editShiftHeader">Edit Shift</h3>
+      <label className="fromLabel">
         From Time:
         <input
           type="text"
           name="fromTime"
           value={updatedShift.fromTime}
           onChange={handleChange}
+          className="shiftTime"
         />
       </label>
-      <label>
+      <label className="toLabel">
         To Time:
         <input
           type="text"
@@ -43,7 +44,7 @@ export const EditRequestModal = ({ isOpen, onClose, shift, onSave }) => {
           onChange={handleChange}
         />
       </label>
-      <label>
+      <label className="volunteersRequestedLabel">
         Volunteers Requested:
         <input
           type="number"
@@ -52,8 +53,8 @@ export const EditRequestModal = ({ isOpen, onClose, shift, onSave }) => {
           onChange={handleChange}
         />
       </label>
-      <button onClick={handleSave}>Save</button>
-      <button onClick={onClose}>Cancel</button>
+      <button className="saveButton" onClick={handleSave}>Save</button>
+      <button className="cancelButton" onClick={onClose}>Cancel</button>
     </div>
   );
 

--- a/client_app/src/components/shelter/NotifyFrequentVolunteersModal.js
+++ b/client_app/src/components/shelter/NotifyFrequentVolunteersModal.js
@@ -21,8 +21,8 @@ export const NotifyVolunteersModal = ({ isOpen, onClose, onNotify }) => {
         placeholder="Type your message here..."
       />
       <div className="button-container">
-        <button onClick={handleNotify}>Send Notification</button>
-        <button onClick={onClose}>Cancel</button>
+        <button className="notifyButton" onClick={handleNotify}>Send Notification</button>
+        <button className="cancelButton" onClick={onClose}>Cancel</button>
       </div>
     </div>
   );

--- a/client_app/src/components/shelter/ShelterConstants.tsx
+++ b/client_app/src/components/shelter/ShelterConstants.tsx
@@ -1,0 +1,13 @@
+export const shiftDetailsAlwaysShowCols = [
+  "Date", 
+  "Shift",
+  "Coverage"
+]
+
+export const shiftDetailsColumnsToRender = [
+  ...shiftDetailsAlwaysShowCols,
+  "View Volunteers",
+  "Open/Close Sign Up",
+  "Edit Shift", 
+  "Contact Volunteers"
+]

--- a/client_app/src/components/shelter/ShiftDetails.js
+++ b/client_app/src/components/shelter/ShiftDetails.js
@@ -9,7 +9,7 @@ import dayjsTimezone from 'dayjs/plugin/timezone';
 import { ShiftDetailsTable } from "./ShiftDetailsTable.js";
 import { ShiftsModal } from "./ShiftsModal.js";
 import { useState } from 'react';
-import { EmergencyAlertModal } from "./EmergencyAlertModal";
+import { ContactVolunteersModal } from "./ContactVolunteersModal";
 import { EditStatusConfirmationModal } from "./EditStatusConfirmationModal";
 import { availableShifts } from "./ShiftDetailsData.tsx";
 import OutlinedInput from '@mui/material/OutlinedInput';
@@ -25,14 +25,14 @@ dayjs.extend(dayjsUTC);
 dayjs.extend(dayjsTimezone);
 
 export const ShiftDetails = () => {
-    const [isEmergencyModalOpen, setIsEmergencyModalOpen] = useState(false);
+    const [isContactVolunteersModalOpen, setIsContactVolunteersModalOpen] = useState(false);
     const [isVolunteerModalOpen, setIsVolunteerModalOpen] = useState(false);
     const [isStatusModalOpen, setIsStatusModalOpen] = useState(false);
     const [shift, setShift] = useState();
     const shiftsList = availableShifts;
     const [selectedShifts, setSelectedShift] = useState([]);
-    const stickyHeader = (isEmergencyModalOpen || isVolunteerModalOpen || isStatusModalOpen) ? "static" : "sticky";
-    const headerZIndex = (isEmergencyModalOpen || isVolunteerModalOpen || isStatusModalOpen) ? 0 : 1;
+    const stickyHeader = (isContactVolunteersModalOpen || isVolunteerModalOpen || isStatusModalOpen) ? "static" : "sticky";
+    const headerZIndex = (isContactVolunteersModalOpen || isVolunteerModalOpen || isStatusModalOpen) ? 0 : 1;
 
     const handleChange = (event) => {
       const {
@@ -47,8 +47,8 @@ export const ShiftDetails = () => {
       setIsVolunteerModalOpen(true);
     }
 
-    const onSendEmergencyAlertClick = () => {
-      setIsEmergencyModalOpen(true);
+    const onSendVolunteerMessageClick = () => {
+      setIsContactVolunteersModalOpen(true);
     }
 
     const onStatusModalClick = shift => {
@@ -71,7 +71,7 @@ export const ShiftDetails = () => {
     return (
       <div>
         {isVolunteerModalOpen && <ShiftsModal isVolunteerModalOpen={isVolunteerModalOpen} setIsVolunteerModalOpen={setIsVolunteerModalOpen} />}
-        {isEmergencyModalOpen && <EmergencyAlertModal isEmergencyModalOpen={isEmergencyModalOpen} setIsEmergencyModalOpen={setIsEmergencyModalOpen} />}
+        {isContactVolunteersModalOpen && <ContactVolunteersModal isContactVolunteersModalOpen={isContactVolunteersModalOpen} setIsContactVolunteersModalOpen={setIsContactVolunteersModalOpen} />}
         {isStatusModalOpen && <EditStatusConfirmationModal isStatusModalOpen={isStatusModalOpen} setIsStatusModalOpen={setIsStatusModalOpen} shift={shift}/>}
         <div className="shift-details">
           <div className="datetime-picker">
@@ -83,7 +83,7 @@ export const ShiftDetails = () => {
             </LocalizationProvider>
             <h4 className="endtime-label">Select Shift(s): </h4>
             <FormControl sx={{ m: .5, width: 250}}>
-              <InputLabel id="shiftsCheckedDropDown" hidden={isEmergencyModalOpen||isStatusModalOpen||isVolunteerModalOpen}>Shift(s)</InputLabel>
+              <InputLabel id="shiftsCheckedDropDown" hidden={isContactVolunteersModalOpen||isStatusModalOpen||isVolunteerModalOpen}>Shift(s)</InputLabel>
               <Select
                 labelId="shiftCheckboxLabel"
                 id="multiShiftCheckboxLabel"
@@ -101,7 +101,7 @@ export const ShiftDetails = () => {
         <div className="shiftdetails-table">
           <ShiftDetailsTable 
             onSignUpVolunteersClick={onSignUpVolunteersClick} 
-            onSendEmergencyAlertClick={onSendEmergencyAlertClick} 
+            onSendVolunteerMessageClick={onSendVolunteerMessageClick} 
             onStatusModalClick={onStatusModalClick}
             stickyHeader={stickyHeader}
             headerZIndex={headerZIndex}/>

--- a/client_app/src/components/shelter/ShiftDetailsData.tsx
+++ b/client_app/src/components/shelter/ShiftDetailsData.tsx
@@ -3,8 +3,8 @@ export const shiftDetailsData = {
       {
         id: 1,
         name: "Morning",
-        startTime: 1728572400000,
-        endTime: 1728586800000,
+        startTime: 1731284457000,
+        endTime: 1731306057000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 2,
         desiredVolunteers: 8,
@@ -13,8 +13,8 @@ export const shiftDetailsData = {
       },
       {
         id: 2,
-        startTime: 1728572400000,
-        endTime: 1728586800000,
+        startTime: 1731284457000,
+        endTime: 1731306057000,
         requiredVolunteers: 3,
         currentSignedUpVolunteers: 6,
         desiredVolunteers: 8,

--- a/client_app/src/components/shelter/ShiftDetailsTable.js
+++ b/client_app/src/components/shelter/ShiftDetailsTable.js
@@ -19,8 +19,8 @@ export const ShiftDetailsTable = props => {
     headerZIndex,
     } = props;
   const [isMobileView, setIsMobileView] = useState(window.innerWidth < 430);
-  const colsToRender = isMobileView ? shiftDetailsAlwaysShowCols : shiftDetailsColumnsToRender;
   const [areColsExpanded, setAreColsExpanded] = useState(false);
+  const colsToRender = (isMobileView && !areColsExpanded) ? shiftDetailsAlwaysShowCols : shiftDetailsColumnsToRender;
   let prevStartDate = "0/0/0000";
 
   useEffect(() => {

--- a/client_app/src/components/shelter/ShiftDetailsTable.js
+++ b/client_app/src/components/shelter/ShiftDetailsTable.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect, useState} from "react";
 import "../../styles/shelter/ShiftDetailsTable.css";
 import { shiftDetailsData } from './ShiftDetailsData.tsx';
 import Tooltip from "@mui/material/Tooltip";
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope, faCheck, faX, faPenToSquare, faTriangleExclamation} from '@fortawesome/free-solid-svg-icons';
 import { useNavigate } from "react-router-dom";
 import { format } from "date-fns";
+import { shiftDetailsAlwaysShowCols,  shiftDetailsColumnsToRender} from "./ShelterConstants.tsx";
 
 export const ShiftDetailsTable = props => {
   const navigate = useNavigate();
@@ -17,6 +18,18 @@ export const ShiftDetailsTable = props => {
     stickyHeader,
     headerZIndex,
     } = props;
+  const [isMobileView, setIsMobileView] = useState(window.innerWidth < 430);
+  const colsToRender = isMobileView ? shiftDetailsAlwaysShowCols : shiftDetailsColumnsToRender;
+  const [areColsExpanded, setAreColsExpanded] = useState(false);
+  let prevStartDate = "0/0/0000";
+
+  useEffect(() => {
+    const handleResize = () => setIsMobileView(window.innerWidth < 430);
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
 
   const emailButton = () => {
     return (
@@ -93,32 +106,52 @@ export const ShiftDetailsTable = props => {
     }
   }
 
+  const renderCondensedCols = () => {
+    return (shiftDetailsData.data.map((shift) => (
+      <tr key={shift.id} style={{background:getShiftColor(shift)}}>
+        <td>{format(shift.startTime, "MM/dd/yyyy")}</td>
+        <td>{shift.name ? shift.name + ": " + format(shift.startTime, "hh:mm aaaaa'm'") + ' - ' + format(shift.endTime, "hh:mm aaaaa'm'") : format(shift.startTime, "hh:mm aaaaa'm'") + ' - ' + format(shift.endTime, "hh:mm aaaaa'm'")}</td>
+        <td>{renderCoverage(shift)}</td>
+      </tr>)))
+  }
+
+  const renderAllCols = () => {
+    return (shiftDetailsData.data.map((shift) => (
+      <tr key={shift.id} style={{background:getShiftColor(shift)}}>
+        <td>{format(shift.startTime, "MM/dd/yyyy")}</td>
+        <td>{shift.name ? shift.name + ": " + format(shift.startTime, "hh:mm aaaaa'm'") + ' - ' + format(shift.endTime, "hh:mm aaaaa'm'") : format(shift.startTime, "hh:mm aaaaa'm'") + ' - ' + format(shift.endTime, "hh:mm aaaaa'm'")}</td>
+        <td>{renderCoverage(shift)}</td>
+        <td>{viewRosterButton()}</td>
+        <td>{shift.status ? openStatusButton(shift) : closedStatusButton(shift)}</td>
+        <td>{editButton(shift)}</td>
+        <td>{emailButton()}</td>
+      </tr>
+    )))
+  }
+
+  const getShiftColor = shift => {
+    if (format(shift.startTime, "MM/dd/yyyy") != prevStartDate) {
+      prevStartDate = format(shift.startTime, "MM/dd/yyyy");
+      return "#e6e6e6";
+    } else {
+      return "white";
+    }
+  }
+
   return (
     <div className="shiftdetails-container">
+      {(!areColsExpanded && isMobileView) && <button onClick={() => {setAreColsExpanded(true)}}>View All Columns</button>}
+      {(isMobileView && areColsExpanded) && <button onClick={() => {setAreColsExpanded(false)}}>Collapse Columns</button>}
       <table className="shiftsTable">
         <thead className="shiftsTableHeader" style={{position:stickyHeader,zIndex:headerZIndex,top:-1}}>
           <tr>
-            <th>Date</th>
-            <th>Shift</th>
-            <th>Coverage</th>
-            <th>View Volunteers</th>
-            <th>Open/Close Sign Up</th>
-            <th>Edit Shift</th>
-            <th>Contact Volunteers</th>
+            {colsToRender.map((label) => (
+              <th key={label}>{label}</th>
+            ))}
           </tr>
         </thead>
         <tbody className="shiftsTableBody">
-          {shiftDetailsData.data.map((shift) => (
-            <tr key={shift.id}>
-              <td>{format(shift.startTime, "MM/dd/yyyy")}</td>
-              <td>{shift.name ? shift.name + ": " + format(shift.startTime, "hh:mm aaaaa'm'") + ' - ' + format(shift.endTime, "hh:mm aaaaa'm'") : format(shift.startTime, "hh:mm aaaaa'm'") + ' - ' + format(shift.endTime, "hh:mm aaaaa'm'")}</td>
-              <td>{renderCoverage(shift)}</td>
-              <td>{viewRosterButton()}</td>
-              <td>{shift.status ? openStatusButton(shift) : closedStatusButton(shift)}</td>
-              <td>{editButton(shift)}</td>
-              <td>{emailButton()}</td>
-            </tr>
-          ))}
+          {(isMobileView && !areColsExpanded) ? renderCondensedCols() : renderAllCols()}
         </tbody>
       </table>
     </div>

--- a/client_app/src/components/shelter/ShiftDetailsTable.js
+++ b/client_app/src/components/shelter/ShiftDetailsTable.js
@@ -12,7 +12,7 @@ export const ShiftDetailsTable = props => {
   const navigate = useNavigate();
   const { 
     onSignUpVolunteersClick , 
-    onSendEmergencyAlertClick, 
+    onSendVolunteerMessageClick, 
     onStatusModalClick,
     stickyHeader,
     headerZIndex,
@@ -20,7 +20,7 @@ export const ShiftDetailsTable = props => {
 
   const emailButton = () => {
     return (
-      <button className="emailButton" onClick={onSendEmergencyAlertClick}>
+      <button className="emailButton" onClick={onSendVolunteerMessageClick}>
         <FontAwesomeIcon icon={faEnvelope} size="2x" className="emailIcon" />
       </button>
     )
@@ -104,7 +104,7 @@ export const ShiftDetailsTable = props => {
             <th>View Volunteers</th>
             <th>Open/Close Sign Up</th>
             <th>Edit Shift</th>
-            <th>Send Emergency Alert</th>
+            <th>Contact Volunteers</th>
           </tr>
         </thead>
         <tbody className="shiftsTableBody">

--- a/client_app/src/styles/shelter/CancelRequestModal.css
+++ b/client_app/src/styles/shelter/CancelRequestModal.css
@@ -10,7 +10,8 @@
     margin-top: 15px; 
   }
   
-  .button-container button {
+  .confirmationButton, 
+  .cancellationButton {
     padding: 10px 20px;
     background-color: #1e4c5b;
     color: white;

--- a/client_app/src/styles/shelter/ContactVolunteersModal.css
+++ b/client_app/src/styles/shelter/ContactVolunteersModal.css
@@ -1,7 +1,7 @@
-.emergencyMessage {
+.volunteerMessage {
   background-color: white;
   height: 30vh;
-  width: 70vw;
+  width: 45vw;
   margin-left: auto;
   margin-right: auto;
   display: block;

--- a/client_app/src/styles/shelter/EditRequestModal.css
+++ b/client_app/src/styles/shelter/EditRequestModal.css
@@ -1,4 +1,4 @@
-.modalComponent {
+.modalEditRequest {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -9,12 +9,12 @@
     border-radius: 8px;
   }
   
-  .modalComponent h3 {
+  .editShiftHeader {
     margin-bottom: 20px;
     font-size: 1.5em;
   }
   
-  .modalComponent label {
+  .fromLabel {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -24,7 +24,7 @@
     font-size: 1em;
   }
   
-  .modalComponent input {
+  .shiftTime {
     padding: 8px;
     width: 60%;
     border: 1px solid #ccc;
@@ -39,21 +39,12 @@
     margin-top: 20px;
   }
   
-  .modalComponent button {
+  .saveButton, .cancelButton {
     padding: 8px 20px;
     border: none;
     border-radius: 5px;
     cursor: pointer;
     margin: 0 100px;
-  }
-  
-  .modalComponent .close-btn {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    background: none;
-    border: none;
-    cursor: pointer;
   }
 
 

--- a/client_app/src/styles/shelter/Modal.css
+++ b/client_app/src/styles/shelter/Modal.css
@@ -15,12 +15,11 @@
 
 .close-btn {
   background-color: transparent;
-            top: 0px;
-            right: 0px;
 }
 
 .closeIcon {
   color: black;
   position: absolute;
-
+  right: 3%;
+  top: 6%;
 }

--- a/client_app/src/styles/shelter/Modal.css
+++ b/client_app/src/styles/shelter/Modal.css
@@ -15,11 +15,12 @@
 
 .close-btn {
   background-color: transparent;
+            top: 0px;
+            right: 0px;
 }
 
 .closeIcon {
   color: black;
   position: absolute;
-  right: 3%;
-  top: 6%;
+
 }

--- a/client_app/src/styles/shelter/NotifyFrequentVolunteersModal.css
+++ b/client_app/src/styles/shelter/NotifyFrequentVolunteersModal.css
@@ -16,7 +16,7 @@
     margin-top: 15px;
   }
   
-  .button-container button {
+  .notifyButton, .cancelButton{
     padding: 10px 20px;
     background-color: #1e4c5b;
     color: white;

--- a/client_app/src/styles/shelter/ShiftDetailsTable.css
+++ b/client_app/src/styles/shelter/ShiftDetailsTable.css
@@ -58,6 +58,13 @@
   max-height: 70vh;
 }
 
+.shiftdetails-container button {
+  max-width: fit-content;
+  border-radius: 10px;
+  margin-bottom: 2%;
+  margin-left: 1%;
+}
+
 table {
   width: 100%;
   overflow-x: auto;
@@ -70,4 +77,8 @@ tbody {
   overflow-y: auto;
   max-height: 60vh;
   min-width: fit-content;
+}
+
+.shiftdetails-container tr {
+  height: 5em;
 }


### PR DESCRIPTION
Fixes #142 

**What was changed?**

Changed the mobile view to only render 3  most important columns (Date, Shift, Coverage) and let the user expand the columns. The row is highlighted grey when the date differs from the previous ones (these will be in order when the table is rendered). Updated Emergency Alert to Contact Volunteers. 


**Why was it changed?**

Update to what our client wanted for the UI. 

**How was it changed?**

I had to update the css files from the Upcoming Shifts page modals because their styling affected all modals (I just added className attributes). I update the name and variable names to reflect contact volunteers. Use dynamic rendering and document queries to change the columns rendered based on the size of the window screen and in this file added buttons for collapsing and expanding those columns when the user is in mobile view. 

<img width="218" alt="Screenshot 2024-11-10 at 7 39 01 PM" src="https://github.com/user-attachments/assets/4ba379b4-e399-4026-bb43-427439f22678">
<img width="211" alt="Screenshot 2024-11-10 at 7 39 13 PM" src="https://github.com/user-attachments/assets/3d171ba3-5d7d-4cdf-ac86-5caa8f20edf4">
<img width="1440" alt="Screenshot 2024-11-10 at 7 39 18 PM" src="https://github.com/user-attachments/assets/a28f5312-f267-4e0b-bef5-ba978b4e1ddb">
<img width="908" alt="Screenshot 2024-11-10 at 7 39 23 PM" src="https://github.com/user-attachments/assets/7ec5c819-7bb1-4fe3-9dc6-9a0aa98a3760">

