### PR TITLE
Update Use Case for Adding Shifts (#151) Fixed

### DIFF
--- a/server/use_cases/add_volunteer_shifts.py
+++ b/server/use_cases/add_volunteer_shifts.py
@@ -1,7 +1,7 @@
 """
 This module contains the use case for adding work shifts.
 """
-# from domains.shift import Shift
+from domains.work_shift import WorkShift
 
 
 def workshift_add_use_case(repo, new_shift, existing_shifts):
@@ -28,9 +28,9 @@ def workshift_add_multiple_use_case(repo, work_shifts, user_id):
     if not work_shifts:
         return []
     
-    # add the Volunteer object in the repo and 
-    # create get_shifts_for_volunteer function
-    # to get the value of the sign_up_shifts
+    #add the Volunteer object in the repo and
+    #create get_shifts_for_volunteer function
+    #to get the value of the sign_up_shifts
     existing_shifts = repo.get_shifts_for_volunteer(user_id) 
     responses = []
 

--- a/server/use_cases/add_volunteer_shifts.py
+++ b/server/use_cases/add_volunteer_shifts.py
@@ -28,7 +28,8 @@ def workshift_add_multiple_use_case(repo, work_shifts, user_id):
     if not work_shifts:
         return []
     
-    # add the Volunteer object in the repo and create get_shifts_for_volunteer function
+    # add the Volunteer object in the repo and 
+    # create get_shifts_for_volunteer function
     # to get the value of the sign_up_shifts
     existing_shifts = repo.get_shifts_for_volunteer(user_id) 
     responses = []

--- a/server/use_cases/add_volunteer_shifts.py
+++ b/server/use_cases/add_volunteer_shifts.py
@@ -1,0 +1,64 @@
+"""
+This module contains the use case for adding work shifts.
+"""
+# from domains.shift import Shift
+
+
+def workshift_add_use_case(repo, new_shift, existing_shifts):
+    """
+    The function adds a work shift into the chosen database
+    after checking for overlaps with existing shifts.
+    """
+    if shift_already_exists(new_shift, existing_shifts):
+        return {"success": False,
+                "message": "You are signed up for another shift at this time"}
+    new_shift_dict = new_shift.to_dict()
+    repo.add(new_shift_dict)
+    shift_id = new_shift_dict["_id"]
+    new_shift.set_id(shift_id)
+    new_shift_dict= new_shift.to_dict()
+    return {"id":shift_id, "success": True,
+            "message": "Shift added successfully"}
+
+
+def workshift_add_multiple_use_case(repo, work_shifts, user_id):
+    """
+    Adds multiple work shifts into the database after checking for overlap.
+    """
+    if not work_shifts:
+        return []
+    
+    # add the Volunteer object in the repo and create get_shifts_for_volunteer function
+    # to get the value of the sign_up_shifts
+    existing_shifts = repo.get_shifts_for_volunteer(user_id) 
+    responses = []
+
+    for work_shift_dict in work_shifts:
+        new_shift = WorkShift.from_dict(work_shift_dict)
+        add_response = workshift_add_use_case(repo, new_shift, existing_shifts)
+        shift_id=str(new_shift.get_id())
+        response_item = {"code": shift_id, "success": add_response["success"]}
+        if not add_response["success"]:
+            response_item["error"] = add_response["message"]
+        responses.append(response_item)
+        if add_response["success"]:
+            existing_shifts.append(new_shift)
+
+    return responses
+
+def shift_already_exists(new_shift, existing_shifts):
+    """
+    Checks if the new_shift overlaps with any of the existing_shifts.
+    Assumes that new_shift and existing_shifts are WorkShift objects.
+    """
+    new_shift_start = new_shift.start_time
+    new_shift_end = new_shift.end_time
+
+    for shift in existing_shifts:
+        existing_start = shift.start_time
+        existing_end = shift.end_time
+        if (max(existing_start, new_shift_start) <
+            min(existing_end, new_shift_end)):
+            return True
+    return False
+

--- a/server/use_cases/add_volunteer_shifts.py
+++ b/server/use_cases/add_volunteer_shifts.py
@@ -4,7 +4,7 @@ This module contains the use case for adding work shifts.
 from domains.work_shift import WorkShift
 
 
-def workshift_add_use_case(repo, new_shift, existing_shifts):
+def shift_add_use_case(repo, new_shift, existing_shifts):
     """
     The function adds a work shift into the chosen database
     after checking for overlaps with existing shifts.
@@ -21,17 +21,16 @@ def workshift_add_use_case(repo, new_shift, existing_shifts):
             "message": "Shift added successfully"}
 
 
-def workshift_add_multiple_use_case(repo, work_shifts, user_id):
+def shift_add_multiple_use_case(repo, work_shifts, user_id):
     """
     Adds multiple work shifts into the database after checking for overlap.
     """
     if not work_shifts:
         return []
-    
     #add the Volunteer object in the repo and
     #create get_shifts_for_volunteer function
     #to get the value of the sign_up_shifts
-    existing_shifts = repo.get_shifts_for_volunteer(user_id) 
+    existing_shifts = repo.get_shifts_for_volunteer(user_id)
     responses = []
 
     for work_shift_dict in work_shifts:

--- a/server/use_cases/add_volunteer_shifts.py
+++ b/server/use_cases/add_volunteer_shifts.py
@@ -35,7 +35,7 @@ def shift_add_multiple_use_case(repo, work_shifts, user_id):
 
     for work_shift_dict in work_shifts:
         new_shift = WorkShift.from_dict(work_shift_dict)
-        add_response = workshift_add_use_case(repo, new_shift, existing_shifts)
+        add_response = shift_add_use_case(repo, new_shift, existing_shifts)
         shift_id=str(new_shift.get_id())
         response_item = {"code": shift_id, "success": add_response["success"]}
         if not add_response["success"]:


### PR DESCRIPTION
Fixes #151 

**What was changed?**

I changed the add_shifts function in the back.

**Why was it changed?**

It was changed because we implemented a new database structure. In the future, we will have two objects: Shift and Volunteer. We need to update the add_shifts function to reflect that.

**How was it changed?**

I added a new file named add_volunteer_shifts. I reused the code from the add_workshifts.py file, changed the function names and updated the shift_add_multiple_use_case() function to take another parameter, which is user_id. To get all the shifts from the volunteer, we now call the get_shifts_for_volunteer() function from repo. 

**Screenshots that show the changes (if applicable):**
