### PR TITLE
Fixed: Added functionality to delete work shift from a volunteer with new database objects (Issue #150)

### DIFF
--- a/server/domains/shelter_volunteer.py
+++ b/server/domains/shelter_volunteer.py
@@ -1,0 +1,32 @@
+"""
+This module handles data conversion from dictionary to class obj or vice versa
+"""
+from typing import List
+import dataclasses
+@dataclasses.dataclass
+class ShelterVolunteer:
+    """
+    Data class for keeping track of the number of workers and which workers
+    signed up for a given time interval
+    """
+    email: str
+    first_name: str
+    last_name: str
+    phone_number: str
+    signed_up_shifts: List[int]
+
+    @classmethod
+    def from_dict(self, d):
+        """
+        The function is a class method that takes in a dictionary
+        and returns an instance of the class
+        """
+        return self(**d)
+
+    def to_dict(self):
+        """
+        The function takes an object and returns a dictionary
+        representation of the object
+        """
+        return dataclasses.asdict(self)
+    

--- a/server/repository/memrepo.py
+++ b/server/repository/memrepo.py
@@ -43,7 +43,7 @@ class MemRepo:
                 return
 
     # This is for the new use case of a volunteer deleting a shift
-    def delete_shift_use_case(self, shift_id, user_id): 
+    def delete_shift_use_case(self, shift_id, user_id):
         for item in self.data:
             if shift_id in item["signed_up_shifts"] and item["id"] == user_id:
                 item["signed_up_shifts"].remove(shift_id)

--- a/server/repository/memrepo.py
+++ b/server/repository/memrepo.py
@@ -41,7 +41,7 @@ class MemRepo:
             if item["_id"] == shift_id:
                 self.data.remove(item)
                 return
-    
+
     def delete_shift_use_case(self, shift_id, user_id):
         for item in self.data:
             if shift_id in item["signed_up_shifts"] and item["id"] == user_id:

--- a/server/repository/memrepo.py
+++ b/server/repository/memrepo.py
@@ -41,4 +41,10 @@ class MemRepo:
             if item["_id"] == shift_id:
                 self.data.remove(item)
                 return
+    
+    def delete_shift_use_case(self, shift_id, user_id): 
+        for item in self.data:
+            if shift_id in item["signed_up_shifts"] and item["id"] == user_id:
+                item["signed_up_shifts"].remove(shift_id)
+                return
 

--- a/server/repository/memrepo.py
+++ b/server/repository/memrepo.py
@@ -42,7 +42,8 @@ class MemRepo:
                 self.data.remove(item)
                 return
 
-    def delete_shift_use_case(self, shift_id, user_id):
+    # This is for the new use case of a volunteer deleting a shift
+    def delete_shift_use_case(self, shift_id, user_id): 
         for item in self.data:
             if shift_id in item["signed_up_shifts"] and item["id"] == user_id:
                 item["signed_up_shifts"].remove(shift_id)

--- a/server/repository/memrepo.py
+++ b/server/repository/memrepo.py
@@ -42,9 +42,8 @@ class MemRepo:
                 self.data.remove(item)
                 return
     
-    def delete_shift_use_case(self, shift_id, user_id): 
+    def delete_shift_use_case(self, shift_id, user_id):
         for item in self.data:
             if shift_id in item["signed_up_shifts"] and item["id"] == user_id:
                 item["signed_up_shifts"].remove(shift_id)
                 return
-

--- a/server/repository/mongorepo.py
+++ b/server/repository/mongorepo.py
@@ -80,6 +80,7 @@ class MongoRepo:
         self.collection.delete_one({"_id": ObjectId(shift_id)})
         return
 
+    # This is the logic connecting the the DB for deleting a shift
     def delete_volunteer_shift(self, shift_id, user_id):
         """
         Removes the shift instance in 

--- a/server/repository/mongorepo.py
+++ b/server/repository/mongorepo.py
@@ -79,7 +79,7 @@ class MongoRepo:
         """
         self.collection.delete_one({"_id": ObjectId(shift_id)})
         return
-    
+
     def delete_volunteer_shift(self, shift_id, user_id):
         """
         Removes the shift instance in 

--- a/server/repository/mongorepo.py
+++ b/server/repository/mongorepo.py
@@ -79,6 +79,13 @@ class MongoRepo:
         """
         self.collection.delete_one({"_id": ObjectId(shift_id)})
         return
+    
+    def delete_volunteer_shift(self, shift_id, user_id): 
+        """
+        Removes the shift instance in volunteer's shifts from the database
+        """
+        self.collection.update_one({"id": user_id}, {"$pull": {"signed_up_shifts": shift_id}})
+        return
 
     def get_shifts_for_user(self, user_id):
         """

--- a/server/repository/mongorepo.py
+++ b/server/repository/mongorepo.py
@@ -80,11 +80,13 @@ class MongoRepo:
         self.collection.delete_one({"_id": ObjectId(shift_id)})
         return
     
-    def delete_volunteer_shift(self, shift_id, user_id): 
+    def delete_volunteer_shift(self, shift_id, user_id):
         """
-        Removes the shift instance in volunteer's shifts from the database
+        Removes the shift instance in 
+        volunteer's shifts from the database.
         """
-        self.collection.update_one({"id": user_id}, {"$pull": {"signed_up_shifts": shift_id}})
+        self.collection.update_one({"id": user_id},
+                                   {"$pull": {"signed_up_shifts": shift_id}})
         return
 
     def get_shifts_for_user(self, user_id):

--- a/server/serializers/shelter_volunteer.py
+++ b/server/serializers/shelter_volunteer.py
@@ -1,0 +1,21 @@
+"""
+This module is for a custom JSON encoder for serializing Volunteer objects.
+"""
+import json
+
+class ShelterVolunteerJsonEncoder(json.JSONEncoder):
+    """Encode a Volunteer object to JSON."""
+    def default(self, sheltervolunteer):
+        """Encode a WorkShift object to JSON."""
+        try:
+            to_serialize = {
+                "email": sheltervolunteer.email,
+                "first_name": sheltervolunteer.first_name,
+                "last_name": sheltervolunteer.last_name,
+                "phone_number": sheltervolunteer.phone_number,
+                "signed_up_shifts": sheltervolunteer.signed_up_shifts,
+            }
+            return to_serialize
+        except AttributeError:
+            return super().default(sheltervolunteer)
+        

--- a/server/use_cases/delete_volunteer_shift.py
+++ b/server/use_cases/delete_volunteer_shift.py
@@ -1,0 +1,32 @@
+"""
+Module containing the use case for deleting volunteer shifts.
+"""
+
+from responses import (
+    ResponseSuccess,
+    ResponseFailure,
+    ResponseTypes
+)
+
+def delete_shift_use_case(repo, shift_id, user_email):
+    """
+    Delete a specific shift based on ID and user email.
+    """
+    try:
+        volunteer = repo.get_by_id(user_email)
+
+        if volunteer is None:
+            return ResponseFailure(ResponseTypes.NOT_FOUND, "Volunteer not found")
+        
+        if shift_id not in volunteer.signed_up_shifts:
+            return ResponseFailure(ResponseTypes.NOT_FOUND, "Shift not found under volunteer")
+            
+        repo.delete_volunteer_shift(user_id=user_email, shift_id=shift_id)  
+        return ResponseSuccess({"message": "Shift deleted successfully"})  
+            
+    except AttributeError:
+        return ResponseFailure(ResponseTypes.PARAMETER_ERROR,
+                            "Invalid request parameters.")
+    except ValueError: # Catch unexpected exceptions.
+        return ResponseFailure(ResponseTypes.SYSTEM_ERROR,
+                               "An unexpected error occurred.")

--- a/server/use_cases/delete_volunteer_shift.py
+++ b/server/use_cases/delete_volunteer_shift.py
@@ -19,11 +19,12 @@ def delete_shift_use_case(repo, shift_id, user_email):
             return ResponseFailure(ResponseTypes.NOT_FOUND, "Volunteer not found")
         
         if shift_id not in volunteer.signed_up_shifts:
-            return ResponseFailure(ResponseTypes.NOT_FOUND, "Shift not found under volunteer")
+            return ResponseFailure(ResponseTypes.NOT_FOUND,
+                              "Shift not found under volunteer")
             
-        repo.delete_volunteer_shift(user_id=user_email, shift_id=shift_id)  
-        return ResponseSuccess({"message": "Shift deleted successfully"})  
-            
+        repo.delete_volunteer_shift(user_id=user_email, shift_id=shift_id)
+        return ResponseSuccess({"message": "Shift deleted successfully"})
+
     except AttributeError:
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR,
                             "Invalid request parameters.")

--- a/server/use_cases/delete_volunteer_shift.py
+++ b/server/use_cases/delete_volunteer_shift.py
@@ -16,12 +16,13 @@ def delete_shift_use_case(repo, shift_id, user_email):
         volunteer = repo.get_by_id(user_email)
 
         if volunteer is None:
-            return ResponseFailure(ResponseTypes.NOT_FOUND, "Volunteer not found")
-        
+            return ResponseFailure(ResponseTypes.NOT_FOUND, 
+                              "Volunteer not found")
+
         if shift_id not in volunteer.signed_up_shifts:
             return ResponseFailure(ResponseTypes.NOT_FOUND,
                               "Shift not found under volunteer")
-            
+
         repo.delete_volunteer_shift(user_id=user_email, shift_id=shift_id)
         return ResponseSuccess({"message": "Shift deleted successfully"})
 

--- a/server/use_cases/delete_volunteer_shift.py
+++ b/server/use_cases/delete_volunteer_shift.py
@@ -16,7 +16,7 @@ def delete_shift_use_case(repo, shift_id, user_email):
         volunteer = repo.get_by_id(user_email)
 
         if volunteer is None:
-            return ResponseFailure(ResponseTypes.NOT_FOUND, 
+            return ResponseFailure(ResponseTypes.NOT_FOUND,
                               "Volunteer not found")
 
         if shift_id not in volunteer.signed_up_shifts:


### PR DESCRIPTION
Fixes #150 

**What was changed?**

Added the function to delete a shift from a Volunteer's (object) array of shifts, this is for the use case when a volunteer wants to cancel a shift they signed up for. 

**Why was it changed?**

To reflect the new structure for the back-end as it is updated to support shelter-side logic. 
Here are the objects defined in a doc: https://docs.google.com/document/d/193V1UcgqoHvLwOmyV8xwI5DB2p6P2sP92eAoi3Jg4go/edit?usp=sharing

**How was it changed?**

Created a new file "delete_volunteer_shift.py" that holds the logic to delete the shift instance and handles the error should a shift id not appear in the volunteer's array of signed_up_shifts. I added the functions that separate the Python MongoDB syntax in mongorepo.py and memrepo.py. 
