### PR TITLE
Struct rename

### DIFF
--- a/server/application/rest/work_shift.py
+++ b/server/application/rest/work_shift.py
@@ -20,6 +20,7 @@ from serializers.volunteer import VolunteerJsonEncoder
 from responses import ResponseTypes
 from application.rest.request_from_params import list_shift_request
 import os
+from domains.service_shift import WorkShift
 
 
 blueprint = Blueprint("work_shift", __name__)

--- a/server/application/rest/work_shift.py
+++ b/server/application/rest/work_shift.py
@@ -20,8 +20,6 @@ from serializers.volunteer import VolunteerJsonEncoder
 from responses import ResponseTypes
 from application.rest.request_from_params import list_shift_request
 import os
-from domains.service_shift import WorkShift
-
 
 blueprint = Blueprint("work_shift", __name__)
 

--- a/server/domains/service_commitment.py
+++ b/server/domains/service_commitment.py
@@ -1,0 +1,26 @@
+"""
+This module defines the data model 
+for service commitments.
+A service commitment links a volunteer 
+to a specific service shift.
+"""
+
+import uuid
+import dataclasses
+
+@dataclasses.dataclass
+class ServiceCommitment:
+    """
+    Data class for tracking volunteer commitments to service shifts.
+    """
+    volunteer_id: str
+    service_shift_id: uuid.UUID
+
+    @classmethod
+    def from_dict(cls, data):
+        """Creates a ServiceCommitment instance from a dictionary."""
+        return cls(**data)
+
+    def to_dict(self):
+        """Converts the ServiceCommitment instance to a dictionary."""
+        return dataclasses.asdict(self)

--- a/server/domains/service_shift.py
+++ b/server/domains/service_shift.py
@@ -9,8 +9,10 @@ import uuid
 import dataclasses
 from deprecated import deprecated
 
+@deprecated(
+    reason="WorkShift is deprecated and will be replaced by ServiceCommitment."
+)
 
-@deprecated(reason="WorkShift is deprecated and will be replaced by ServiceCommitment.")
 @dataclasses.dataclass
 class WorkShift:
     """

--- a/server/domains/service_shift.py
+++ b/server/domains/service_shift.py
@@ -1,16 +1,16 @@
 """
-This module defines data classes for service shifts, commitments, and a deprecated
-WorkShift class to support shelter service management.
+This module defines data classes for 
+service shifts and commitments,
+with the deprecated WorkShift 
+class marked for removal.
 """
 
 import uuid
 import dataclasses
-import warnings
 from deprecated import deprecated
 
-@deprecated(
-    reason="WorkShift is deprecated and will be replaced by ServiceCommitment."
-)
+
+@deprecated(reason="WorkShift is deprecated and will be replaced by ServiceCommitment.")
 @dataclasses.dataclass
 class WorkShift:
     """
@@ -20,7 +20,7 @@ class WorkShift:
     first_name: str
     last_name: str
     shelter: int
-    start_time: int  # Number of milliseconds since the Epoch in UTC
+    start_time: int
     end_time: int
     _id: uuid.UUID = None
 
@@ -35,19 +35,12 @@ class WorkShift:
     @classmethod
     def from_dict(cls, d):
         """Creates a WorkShift instance from a dictionary."""
-        warnings.warn(
-            "WorkShift is deprecated. Use ServiceCommitment instead.",
-            DeprecationWarning
-        )
         return cls(**d)
 
     def to_dict(self):
         """Converts the WorkShift instance to a dictionary."""
-        warnings.warn(
-            "WorkShift is deprecated. Use ServiceCommitment instead.",
-            DeprecationWarning
-        )
         return dataclasses.asdict(self)
+
 
 @dataclasses.dataclass
 class ServiceShift:
@@ -55,7 +48,7 @@ class ServiceShift:
     Data class for shelter-defined service shifts.
     """
     shelter: int
-    start_time: int  # Number of milliseconds since the Epoch in UTC
+    start_time: int
     end_time: int
     volunteers_needed: int
     _id: uuid.UUID = None
@@ -77,12 +70,13 @@ class ServiceShift:
         """Converts the ServiceShift instance to a dictionary."""
         return dataclasses.asdict(self)
 
+
 @dataclasses.dataclass
 class ServiceCommitment:
     """
     Data class for tracking volunteer commitments to service shifts.
     """
-    volunteer_id: str  # Email or unique identifier
+    volunteer_id: str
     service_shift_id: uuid.UUID
 
     @classmethod

--- a/server/domains/work_shift.py
+++ b/server/domains/work_shift.py
@@ -1,14 +1,13 @@
-"""
-This module handles data converstion from dictionary to class obj or vice versa
-"""
 import uuid
 import dataclasses
+import warnings
+from deprecated import deprecated
 
-
+@deprecated(reason="WorkShift is deprecated and will be replaced by ServiceCommitment.")
 @dataclasses.dataclass
 class WorkShift:
     """
-    Data class for workshift releated data
+    [DEPRECATED] Data class for work shift-related data.
     """
     worker: str
     first_name: str
@@ -21,21 +20,59 @@ class WorkShift:
     def get_id(self):
         """Returns the ID of the work shift."""
         return self._id
+
     def set_id(self, new_id):
         """Sets the ID of the work shift."""
         self._id = new_id
 
     @classmethod
-    def from_dict(self, d):
-        """
-        The function is a class method that takes in a dictionary
-        and returns an instance of the class.
-        """
-        return self(**d)
+    def from_dict(cls, d):
+        warnings.warn("WorkShift is deprecated. Use ServiceCommitment instead.", DeprecationWarning)
+        return cls(**d)
 
     def to_dict(self):
-        """
-        The function takes an object and returns a dictionary
-        representation of the object.
-        """
+        warnings.warn("WorkShift is deprecated. Use ServiceCommitment instead.", DeprecationWarning)
+        return dataclasses.asdict(self)
+
+# New ServiceShift class replacing Work
+@dataclasses.dataclass
+class ServiceShift:
+    """
+    Data class for shelter-defined service shifts.
+    """
+    shelter: int
+    start_time: int  # number of milliseconds since the Epoch in UTC
+    end_time: int
+    volunteers_needed: int
+    _id: uuid.UUID = None
+
+    def get_id(self):
+        """Returns the ID of the service shift."""
+        return self._id
+
+    def set_id(self, new_id):
+        """Sets the ID of the service shift."""
+        self._id = new_id
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(**d)
+
+    def to_dict(self):
+        return dataclasses.asdict(self)
+
+# New ServiceCommitment class for volunteer sign-ups
+@dataclasses.dataclass
+class ServiceCommitment:
+    """
+    Data class for tracking volunteer commitments to service shifts.
+    """
+    volunteer_id: str  # Email or unique identifier
+    service_shift_id: uuid.UUID
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(**d)
+
+    def to_dict(self):
         return dataclasses.asdict(self)

--- a/server/domains/work_shift.py
+++ b/server/domains/work_shift.py
@@ -1,19 +1,26 @@
+"""
+This module defines data classes for service shifts, commitments, and a deprecated
+WorkShift class to support shelter service management.
+"""
+
 import uuid
 import dataclasses
 import warnings
 from deprecated import deprecated
 
-@deprecated(reason="WorkShift is deprecated and will be replaced by ServiceCommitment.")
+@deprecated(
+    reason="WorkShift is deprecated and will be replaced by ServiceCommitment."
+)
 @dataclasses.dataclass
 class WorkShift:
     """
-    [DEPRECATED] Data class for work shift-related data.
+    Data class for a deprecated WorkShift entity.
     """
     worker: str
     first_name: str
     last_name: str
     shelter: int
-    start_time: int  # number of milliseconds since the Epoch in UTC
+    start_time: int  # Number of milliseconds since the Epoch in UTC
     end_time: int
     _id: uuid.UUID = None
 
@@ -27,21 +34,28 @@ class WorkShift:
 
     @classmethod
     def from_dict(cls, d):
-        warnings.warn("WorkShift is deprecated. Use ServiceCommitment instead.", DeprecationWarning)
+        """Creates a WorkShift instance from a dictionary."""
+        warnings.warn(
+            "WorkShift is deprecated. Use ServiceCommitment instead.",
+            DeprecationWarning
+        )
         return cls(**d)
 
     def to_dict(self):
-        warnings.warn("WorkShift is deprecated. Use ServiceCommitment instead.", DeprecationWarning)
+        """Converts the WorkShift instance to a dictionary."""
+        warnings.warn(
+            "WorkShift is deprecated. Use ServiceCommitment instead.",
+            DeprecationWarning
+        )
         return dataclasses.asdict(self)
 
-# New ServiceShift class replacing Work
 @dataclasses.dataclass
 class ServiceShift:
     """
     Data class for shelter-defined service shifts.
     """
     shelter: int
-    start_time: int  # number of milliseconds since the Epoch in UTC
+    start_time: int  # Number of milliseconds since the Epoch in UTC
     end_time: int
     volunteers_needed: int
     _id: uuid.UUID = None
@@ -56,12 +70,13 @@ class ServiceShift:
 
     @classmethod
     def from_dict(cls, d):
+        """Creates a ServiceShift instance from a dictionary."""
         return cls(**d)
 
     def to_dict(self):
+        """Converts the ServiceShift instance to a dictionary."""
         return dataclasses.asdict(self)
 
-# New ServiceCommitment class for volunteer sign-ups
 @dataclasses.dataclass
 class ServiceCommitment:
     """
@@ -72,7 +87,9 @@ class ServiceCommitment:
 
     @classmethod
     def from_dict(cls, d):
+        """Creates a ServiceCommitment instance from a dictionary."""
         return cls(**d)
 
     def to_dict(self):
+        """Converts the ServiceCommitment instance to a dictionary."""
         return dataclasses.asdict(self)

--- a/server/repository/memrepo.py
+++ b/server/repository/memrepo.py
@@ -1,7 +1,6 @@
 """
 This module is for in-memory repository implementation.
 """
-#from domains.work_shift import WorkShift
 from domains.service_shift import WorkShift
 
 

--- a/server/repository/memrepo.py
+++ b/server/repository/memrepo.py
@@ -1,7 +1,8 @@
 """
 This module is for in-memory repository implementation.
 """
-from domains.work_shift import WorkShift
+#from domains.work_shift import WorkShift
+from domains.service_shift import WorkShift
 
 
 class MemRepo:

--- a/server/repository/mongorepo.py
+++ b/server/repository/mongorepo.py
@@ -2,7 +2,8 @@
 Module handles the mongo DB operations
 """
 import pymongo
-from domains.work_shift import WorkShift
+#from domains.work_shift import WorkShift
+from domains.service_shift import WorkShift
 from bson.objectid import ObjectId
 
 class MongoRepo:

--- a/server/repository/mongorepo.py
+++ b/server/repository/mongorepo.py
@@ -2,7 +2,6 @@
 Module handles the mongo DB operations
 """
 import pymongo
-#from domains.work_shift import WorkShift
 from domains.service_shift import WorkShift
 from bson.objectid import ObjectId
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,3 +3,6 @@ flask-cors
 pymongo
 requests
 python-dotenv
+Deprecated>=1.2.10
+flask-cors
+pymongo

--- a/server/tests/rest/test_work_shift.py
+++ b/server/tests/rest/test_work_shift.py
@@ -5,7 +5,6 @@ from unittest import mock
 from application.app import create_app
 from responses import ResponseSuccess
 from domains.staffing import Staffing
-from domains.service_shift import WorkShift
 
 shifts_data = [
     {

--- a/server/tests/rest/test_work_shift.py
+++ b/server/tests/rest/test_work_shift.py
@@ -5,6 +5,8 @@ from unittest import mock
 from application.app import create_app
 from responses import ResponseSuccess
 from domains.staffing import Staffing
+from domains.service_shift import WorkShift
+
 shifts_data = [
     {
         '_id': 'f853578c-fc0f-4e65-81b8-566c5dffa35a',

--- a/server/tests/use_cases/test_add_workshifts.py
+++ b/server/tests/use_cases/test_add_workshifts.py
@@ -4,9 +4,13 @@ Module containing test cases for adding work shifts.
 
 import pytest
 from unittest import mock
+from domains.service_shift import WorkShift
 
-from domains.work_shift import WorkShift
-from use_cases.add_workshifts import workshift_add_use_case, workshift_add_multiple_use_case
+from use_cases.add_workshifts import (
+    workshift_add_use_case, 
+    workshift_add_multiple_use_case
+)
+from domains.service_shift import WorkShift
 
 @pytest.fixture
 def domain_work_shifts():

--- a/server/tests/use_cases/test_add_workshifts.py
+++ b/server/tests/use_cases/test_add_workshifts.py
@@ -4,13 +4,13 @@ Module containing test cases for adding work shifts.
 
 import pytest
 from unittest import mock
+
 from domains.service_shift import WorkShift
 
 from use_cases.add_workshifts import (
-    workshift_add_use_case, 
+    workshift_add_use_case,
     workshift_add_multiple_use_case
 )
-from domains.service_shift import WorkShift
 
 @pytest.fixture
 def domain_work_shifts():

--- a/server/tests/use_cases/test_count_volunteers.py
+++ b/server/tests/use_cases/test_count_volunteers.py
@@ -4,8 +4,9 @@ This module contains tests for the count volunteers use case
 
 from unittest import mock
 from use_cases.count_volunteers import count_volunteers_use_case
-from domains.work_shift import WorkShift
 from domains.staffing import Staffing
+from domains.service_shift import WorkShift
+
 
 class Object:
     def __init__(self, filters=None):

--- a/server/tests/use_cases/test_delete_workshifts.py
+++ b/server/tests/use_cases/test_delete_workshifts.py
@@ -4,9 +4,11 @@ Tests for the delete work shifts use case.
 
 import uuid
 from unittest import mock
-
-from domains.work_shift import WorkShift
+from domains.service_shift import WorkShift
 from use_cases.delete_workshifts import delete_shift_use_case, ResponseTypes
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+from domains.service_shift import ServiceCommitment
 
 domain_shifts = [
     WorkShift(

--- a/server/tests/use_cases/test_delete_workshifts.py
+++ b/server/tests/use_cases/test_delete_workshifts.py
@@ -1,14 +1,13 @@
 """
 Tests for the delete work shifts use case.
 """
-
 import uuid
+import warnings
 from unittest import mock
 from domains.service_shift import WorkShift
 from use_cases.delete_workshifts import delete_shift_use_case, ResponseTypes
-import warnings
+
 warnings.filterwarnings("ignore", category=DeprecationWarning)
-from domains.service_shift import ServiceCommitment
 
 domain_shifts = [
     WorkShift(

--- a/server/tests/use_cases/test_list_workshifts.py
+++ b/server/tests/use_cases/test_list_workshifts.py
@@ -5,7 +5,7 @@ This module contains tests for the list work shift use cases.
 from unittest import mock
 from use_cases.list_workshifts import workshift_list_use_case
 from responses import ResponseSuccess
-from domains.work_shift import WorkShift
+from domains.service_shift import WorkShift
 
 domain_shifts_data = [
     {

--- a/server/use_cases/add_volunteer_shifts.py
+++ b/server/use_cases/add_volunteer_shifts.py
@@ -1,7 +1,8 @@
 """
 This module contains the use case for adding work shifts.
 """
-from domains.workshift import Work
+# from domains.workshift import Work
+from domains.service_shift import WorkShift
 
 
 def shift_add_use_case(repo, new_shift, existing_shifts):

--- a/server/use_cases/add_volunteer_shifts.py
+++ b/server/use_cases/add_volunteer_shifts.py
@@ -1,9 +1,7 @@
 """
 This module contains the use case for adding work shifts.
 """
-# from domains.workshift import Work
-from domains.service_shift import WorkShift
-
+from domains.workshift import Work
 
 def shift_add_use_case(repo, new_shift, existing_shifts):
     """

--- a/server/use_cases/add_workshifts.py
+++ b/server/use_cases/add_workshifts.py
@@ -1,7 +1,8 @@
 """
 This module contains the use case for adding work shifts.
 """
-from domains.work_shift import WorkShift
+from domains.service_shift import WorkShift
+
 
 def workshift_add_use_case(repo, new_shift, existing_shifts):
     """


### PR DESCRIPTION
Fixes #159 
Now there is an import to deprecated which is reflected in the requirements.txt. Some other additions to requirements.txt include flask-cors, pymongo, and deprecated. One concern that I have is that these packages were already included in the requirements.txt, however my tests would not pass unless I had duplicated those packages. The work structure under server/domains/workshift.py was renamed to ServiceShift and the file was respectively renamed service_shift.py. Files that imported "from domains.work_shift import WorkShift" were changed to "from domains.service_shift import WorkShift" to reflect this change. This was done to reflect the changes in the dependencies within the files. The service_commitment.py was added to enable the eventual replacement of WorkShift.  I created a new file, server/domains/service_commitment.py, and defined the ServiceCommitment class. The ServiceCommitment class links a ServiceShift (via its ID) to a volunteer. 


The changes were made to address evolving requirements for how shelters and volunteers interact with work shifts. Initially, the application was designed under the assumption that volunteers would define their own shifts (start and end times). As development progressed, it became clear that shelters should instead define the shifts, specifying the time slots and the number of volunteers needed for each.


The Work class was renamed to ServiceShift, which better reflects its purpose as a shelter-defined shift. All references to the Work class were updated to use the new ServiceShift class, ensuring consistency and removing potential confusion in the codebase.


The code was changed by the renaming of files. Additionally, I went through and changed each time that WorkShift was imported to a file. Now, each file will reference the new files created (service_shift.py). 

The Work class was renamed to ServiceShift to reflect its role as the shelter-defined shift structure. This new class tracks volunteer sign-ups for shelter-defined shifts. It uses volunteer_id and ServiceShift ID as its fields, ensuring a clear and consistent data model. An important line that I added was "Deprecated>=1.2.10" to the requirements file. I also replaced the imports referring to WorkShift with from "domains.service_shift import WorkShift". 