### PR TITLE
Fixed home dashboard

### DIFF
--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -15,7 +15,7 @@ import { ShiftDetails } from "./components/shelter/ShiftDetails";
 import UpcomingRequests from "./components/shelter/UpcomingRequests";
 import "./styles/App.css";
 import HomeDashboard from "./components/HomeDashboard";
-import { BrowserRouter as Navigate, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 function NavigationControl({ auth }) {
   const location = useLocation(); 
@@ -54,16 +54,6 @@ function App() {
           {/* Protected Routes */}
           <Route path="/" element={<ProtectedRoute />}>
             <Route path="/volunteer-dashboard" element={<VolunteerDashboard />} />
-            <Route
-              path="/home-dashboard"
-              element={
-                auth ? (
-                  <Navigate to="/volunteer-dashboard" />
-                ) : (
-                  <Navigate to="/shelter-dashboard" />
-                )
-              }
-            />
             <Route path="/shelters" element={<Shelters />} />
             <Route path="/past-shifts" element={<PastShifts />} />
             <Route path="/upcoming-shifts" element={<UpcomingShifts />} />

--- a/client_app/src/components/HomeDashboard.js
+++ b/client_app/src/components/HomeDashboard.js
@@ -1,18 +1,9 @@
 import "./../styles/HomeDashboard.css";
 import {useNavigate} from "react-router-dom"; 
-import { useEffect } from "react";
 
 
 function HomeDashboard() {
-    const navigate = useNavigate(); 
-    useEffect(() => {
-      const token = localStorage.getItem("token");
-        
-      if (token) {
-        navigate("/home-dashboard");
-      }
-    }, [navigate]);
-      
+  const navigate = useNavigate();
     return (
       <div className="home-dashboard">
         <header className="home-header">

--- a/client_app/src/components/authentication/Login.js
+++ b/client_app/src/components/authentication/Login.js
@@ -39,7 +39,7 @@ export default function Login({ setAuth, userRole }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await LoginUser(userRole, username, password);
+    await LoginUser(username, password);
     setAuth(true);
     navigate(userRole === "shelter" ? "/shelter-dashboard" : "/volunteer-dashboard");
   };  

--- a/client_app/src/components/volunteer/VolunteerDashboard.js
+++ b/client_app/src/components/volunteer/VolunteerDashboard.js
@@ -13,7 +13,7 @@ function VolunteerDashboard() {
   return (
     <div className="volunteer-dashboard">
       <div className="column column-1">
-        <UpcomingShifts />
+        <h3>Upcoming Shifts</h3><UpcomingShifts />
       </div>
       <div className="column column-2">
         <h3>Shelters looking for Volunteers</h3><Shelters condensed={true} />

--- a/client_app/src/components/volunteer/VolunteerDashboard.js
+++ b/client_app/src/components/volunteer/VolunteerDashboard.js
@@ -13,7 +13,7 @@ function VolunteerDashboard() {
   return (
     <div className="volunteer-dashboard">
       <div className="column column-1">
-        <h3>Upcoming Shifts</h3><UpcomingShifts />
+        <UpcomingShifts />
       </div>
       <div className="column column-2">
         <h3>Shelters looking for Volunteers</h3><Shelters condensed={true} />


### PR DESCRIPTION
When we merged PR #162, we introduced a small problem. If the user already had an authentication token stored in browser cache, no dashboard would show up. This had to do with the way HomeDashboard was defined: it was attempting to re-direct the user to either VolunteerDashboard or ShelterDashboard based on the token that's stored in browser cache. However, for now our token does not distinguish between volunteer and shelter admin, so no dashboard would show up instead.

**What was changed?**
Modified HomeDashboard and App in the client_app, by removing various routes that attempted to do a smart redirect.

