### PR TITLE
refactored the add_service_commitments and list_service_commitments use cases

### DIFF
--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -92,7 +92,7 @@ def fetch_service_commitments():
                 jsonify({"error": "Invalid email format"}),
                 HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR],
             )
-        commitments = list_service_commitments(
+        commitments, _ = list_service_commitments(
             commitments_repo,
             shifts_repo,
             user_email)

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -50,3 +50,10 @@ class ServiceShiftsMongoRepo:
             (filter=db_filter)
         ]
         return service_shifts
+
+    def get_shifts(self, shift_ids):
+        """
+        gets multiple shifts by a list of ids
+        """
+        shifts = self.collection.find({'_id': {'$in': shift_ids}})
+        return [ServiceShift.from_dict(shift) for shift in shifts]

--- a/server/use_cases/add_service_commitments.py
+++ b/server/use_cases/add_service_commitments.py
@@ -3,23 +3,46 @@ Module for handling service commitments.
 Provides functions to create and retrieve service commitments for users.
 """
 
-def add_service_commitments(repo, commitments):
+def add_service_commitments(commitments_repo, shifts_repo, commitments):
     """
     Creates service commitments for the given user and shifts.
 
     Args:
-        repo: A repository object that provides 
-        an insert_service_commitments method.
-        user_email (str): The user's email.
-        shifts (list): A list of shift dictionaries.
+        commitments_repo: A repository object that stores 
+                        all service commitments
+        shifts_repo: A repository object that stores all
+                     service shifts
+        commitments: A list of ServiceCommitment objects to be added
 
     Returns:
         list: A list of dictionaries indicating
         the success and service commitment IDs.
     """
+    shift_ids = [c.service_shift_id for c in commitments]
+    shifts = shifts_repo.get_shifts(shift_ids)
+
+    # temporary implementation for overlapping shifts
+    # Needs to be fixed later to match the requirmenets
+    has_overlap = check_time_overlap(shifts)
+    if has_overlap:
+        return [{
+            "service_commitment_id": None
+            , "success": False}]
+
     commitments_as_dict = [c.to_dict() for c in commitments]
-    repo.insert_service_commitments(commitments_as_dict)
+    commitments_repo.insert_service_commitments(commitments_as_dict)
     return [{
         "service_commitment_id": str(c["_id"])
         , "success": True}
             for c in commitments_as_dict]
+
+def check_time_overlap(shifts):
+    """
+    Check if the shifts have overlapping times.
+    """
+    for i in range(len(shifts)):
+        for j in range(i + 1, len(shifts)):
+            if (shifts[i].shift_start < shifts[j].shift_end and
+                shifts[i].shift_end > shifts[j].shift_start):
+                return True
+    return False

--- a/server/use_cases/list_service_commitments.py
+++ b/server/use_cases/list_service_commitments.py
@@ -2,18 +2,22 @@
 This module contains the use case for listing service commitments.
 """
 
-def list_service_commitments(repo, user_email):
+def list_service_commitments(commitments_repo, shifts_repo, user_email=None):
     """
     Retrieves all service commitments for a given user.
 
     Args:
-        repo: A repository object that provides a 
-        fetch_service_commitments method.
+        commitments_repo: A repository object that contains 
+                          all service commitments
+        shifts_repo: A repository object that contains all service shifts
         user_email (str): The user's email.
 
     Returns:
         list: A list of service commitment dictionaries 
         with IDs and associated service shift IDs.
     """
-    commitments = repo.fetch_service_commitments(user_email)
-    return commitments
+
+    commitments = commitments_repo.fetch_service_commitments(user_email)
+    shift_ids = [commitment.service_shift_id for commitment in commitments]
+    shifts = shifts_repo.get_shifts(shift_ids)
+    return (commitments, shifts)


### PR DESCRIPTION
In preparation for future development, I refactored the add_service_commitments and list_service_commitments use cases to accept two repos as arguments: one for commitments and one for shifts. This is needed because we'll need to do a variety of checks on the commitments when we add them and we'll need to supply shift data when we retrieve commitments