### PR TITLE
try

### DIFF
--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -1,6 +1,7 @@
 """
 This module handles service shift operations.
 """
+import json
 from flask import Blueprint, request, Response, jsonify
 from flask_cors import cross_origin
 from use_cases.add_service_shifts import shift_add_use_case
@@ -10,11 +11,10 @@ from domains.service_shift import ServiceShift
 from application.rest.work_shift import HTTP_STATUS_CODES_MAPPING
 from responses import ResponseTypes
 from serializers.service_shift import ServiceShiftJsonEncoder
-import json
 
-service_shift_bp = Blueprint('service_shift', __name__)
+service_shift_bp = Blueprint("service_shift", __name__)
 
-@service_shift_bp.route('/service_shift', methods=['GET', 'POST'])
+@service_shift_bp.route("/service_shift", methods=["GET", "POST"])
 @cross_origin()
 def handle_service_shift():
     """
@@ -22,68 +22,100 @@ def handle_service_shift():
     """
     repo = ServiceShiftsMongoRepo()
 
-    if request.method == 'GET':
-        shelter_id_string = request.args.get('shelter_id')
-        filter_start_after_string = request.args.get('filter_start_after')
+    if request.method == "GET":
+        shelter_id_string = request.args.get("shelter_id")
+        filter_start_after_string = request.args.get("filter_start_after")
 
         # Ensure proper conversion to int, handling empty or invalid cases
-        shelter_id = int(shelter_id_string) if shelter_id_string and shelter_id_string.isdigit() else None
-        filter_start_after = int(filter_start_after_string) if filter_start_after_string and filter_start_after_string.isdigit() else None
+        shelter_id = (
+            int(shelter_id_string) if shelter_id_string and shelter_id_string.isdigit() else None
+        )
+        filter_start_after = (
+            int(filter_start_after_string) if filter_start_after_string and filter_start_after_string.isdigit() else None
+        )
 
         shifts = service_shifts_list_use_case(repo, shelter_id, filter_start_after)
 
         return Response(
             json.dumps([shift.to_dict() for shift in shifts], cls=ServiceShiftJsonEncoder),
-            mimetype='application/json',
-            status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
+            mimetype="application/json",
+            status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS],
         )
 
-    elif request.method == 'POST':
+    elif request.method == "POST":
         shifts_as_dict = request.get_json()
 
         # Validate that the JSON payload is present
         if not shifts_as_dict:
-            return jsonify({'error': 'Invalid JSON payload'}), 400
+            return jsonify({"error": "Invalid JSON payload"}), 400
 
-        # Convert to ServiceShift objects
         try:
+            # Convert to ServiceShift objects
             shifts_obj = [ServiceShift.from_dict(shift) for shift in shifts_as_dict]
-        except Exception as e:
-            return jsonify({'error': f'Invalid data format: {str(e)}'}), 400
+        except (KeyError, TypeError, ValueError) as err:
+            return jsonify({"error": f"Invalid data format: {str(err)}"}), 400
 
         add_response = shift_add_use_case(repo, shifts_obj)
         status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR]
 
-        if add_response.get('success'):  # Ensure 'success' exists in response
+        if add_response.get("success"):  # Ensure 'success' exists in response
             status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
 
         return Response(
             json.dumps(add_response, default=str),
-            mimetype='application/json',
-            status=status_code
+            mimetype="application/json",
+            status=status_code,
         )
 
-# Ensure ServiceShift class has to_dict() method
+
 class ServiceShift:
-    def __init__(self, id, shelter_id, start_time, end_time):
-        self.id = id
+    """
+    Represents a service shift.
+    """
+
+    def __init__(self, shift_id, shelter_id, start_time, end_time):
+        """
+        Initializes a ServiceShift object.
+
+        Args:
+            shift_id (int): The unique identifier of the shift.
+            shelter_id (int): The shelter ID associated with the shift.
+            start_time (str): The start time of the shift.
+            end_time (str): The end time of the shift.
+        """
+        self.shift_id = shift_id
         self.shelter_id = shelter_id
         self.start_time = start_time
         self.end_time = end_time
 
     def to_dict(self):
+        """
+        Converts a ServiceShift object into a dictionary.
+
+        Returns:
+            dict: Dictionary representation of the service shift.
+        """
         return {
-            'id': self.id,
-            'shelter_id': self.shelter_id,
-            'start_time': self.start_time,
-            'end_time': self.end_time
+            "shift_id": self.shift_id,
+            "shelter_id": self.shelter_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
         }
 
     @classmethod
     def from_dict(cls, data):
+        """
+        Creates a ServiceShift object from a dictionary.
+
+        Args:
+            data (dict): Dictionary containing shift details.
+
+        Returns:
+            ServiceShift: A new instance of the ServiceShift class.
+        """
         return cls(
-            id=data.get('id'),
-            shelter_id=data.get('shelter_id'),
-            start_time=data.get('start_time'),
-            end_time=data.get('end_time')
+            shift_id=data.get("id"),  # Renamed from 'id' to 'shift_id' to avoid conflicts
+            shelter_id=data.get("shelter_id"),
+            start_time=data.get("start_time"),
+            end_time=data.get("end_time"),
         )

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -1,13 +1,12 @@
 """
 This module handles service shift operations.
 """
+
 import json
-from flask import Blueprint, request, Response, jsonify
+from flask import Blueprint, request, Response
 from flask_cors import cross_origin
 from use_cases.add_service_shifts import shift_add_use_case
-from use_cases.list_service_shifts_use_case import (
-    service_shifts_list_use_case,
-)
+from use_cases.list_service_shifts_use_case import service_shifts_list_use_case
 from repository.mongo.service_shifts import ServiceShiftsMongoRepo
 from domains.service_shift import ServiceShift
 from application.rest.work_shift import HTTP_STATUS_CODES_MAPPING
@@ -15,6 +14,7 @@ from responses import ResponseTypes
 from serializers.service_shift import ServiceShiftJsonEncoder
 
 service_shift_bp = Blueprint("service_shift", __name__)
+
 
 @service_shift_bp.route("/service_shift", methods=["GET", "POST"])
 @cross_origin()
@@ -28,27 +28,16 @@ def handle_service_shift():
         shelter_id_str = request.args.get("shelter_id")
         filter_start_after_str = request.args.get("filter_start_after")
 
-        # Convert safely
-        shelter_id = (
-            int(shelter_id_str)
-            if shelter_id_str and shelter_id_str.isdigit()
-            else None
-        )
+        # Ensure proper conversion to int, handling empty or invalid cases
+        shelter_id = int(shelter_id_str) if shelter_id_str and shelter_id_str.isdigit() else None
         filter_start_after = (
-            int(filter_start_after_str)
-            if filter_start_after_str and filter_start_after_str.isdigit()
-            else None
+            int(filter_start_after_str) if filter_start_after_str and filter_start_after_str.isdigit() else None
         )
 
-        shifts = service_shifts_list_use_case(
-            repo, shelter_id, filter_start_after
-        )
+        shifts = service_shifts_list_use_case(repo, shelter_id, filter_start_after)
 
         return Response(
-            json.dumps(
-                [shift.to_dict() for shift in shifts],
-                cls=ServiceShiftJsonEncoder,
-            ),
+            json.dumps(shifts, cls=ServiceShiftJsonEncoder),
             mimetype="application/json",
             status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS],
         )
@@ -58,21 +47,27 @@ def handle_service_shift():
 
         # Validate JSON payload
         if not shifts_as_dict:
-            return jsonify({"error": "Invalid JSON payload"}), 400
+            return Response(
+                json.dumps({"message": "Invalid JSON object"}),
+                mimetype="application/json",
+                status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR],
+            )
 
         try:
-            shifts_obj = [
-                ServiceShift.from_dict(shift)
-                for shift in shifts_as_dict
-            ]
+            shifts_obj = [ServiceShift.from_dict(shift) for shift in shifts_as_dict]
         except (KeyError, TypeError, ValueError) as err:
-            return jsonify({"error": f"Invalid data format: {str(err)}"}), 400
+            return Response(
+                json.dumps({"error": f"Invalid data format: {str(err)}"}),
+                mimetype="application/json",
+                status=400,
+            )
 
         add_response = shift_add_use_case(repo, shifts_obj)
-        status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR]
-
-        if add_response.get("success"):
-            status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
+        status_code = (
+            HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
+            if add_response.get("success")
+            else HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR]
+        )
 
         return Response(
             json.dumps(add_response, default=str),

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -60,7 +60,10 @@ def handle_service_shift():
             )
 
         try:
-            shifts_obj = [ServiceShift.from_dict(shift) for shift in shifts_as_dict]
+            shifts_obj = [
+                ServiceShift.from_dict(shift)
+                for shift in shifts_as_dict
+            ]
         except (KeyError, TypeError, ValueError) as err:
             return Response(
                 json.dumps({"error": f"Invalid data format: {str(err)}"}),

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -40,7 +40,9 @@ def handle_service_shift():
             else None
         )
 
-        shifts = service_shifts_list_use_case(repo, shelter_id, filter_start_after)
+        shifts = service_shifts_list_use_case(
+            repo, shelter_id, filter_start_after
+        )
 
         return Response(
             json.dumps(shifts, cls=ServiceShiftJsonEncoder),

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -16,41 +16,74 @@ service_shift_bp = Blueprint('service_shift', __name__)
 
 @service_shift_bp.route('/service_shift', methods=['GET', 'POST'])
 @cross_origin()
-def service_shift():
+def handle_service_shift():
     """
     Handles POST to add service shifts and GET to list all shifts for a shelter.
     """
     repo = ServiceShiftsMongoRepo()
-    
+
     if request.method == 'GET':
         shelter_id_string = request.args.get('shelter_id')
         filter_start_after_string = request.args.get('filter_start_after')
-        
-        shelter_id = int(shelter_id_string) if shelter_id_string else None
-        filter_start_after = int(filter_start_after_string) if filter_start_after_string else None
-        
+
+        # Ensure proper conversion to int, handling empty or invalid cases
+        shelter_id = int(shelter_id_string) if shelter_id_string and shelter_id_string.isdigit() else None
+        filter_start_after = int(filter_start_after_string) if filter_start_after_string and filter_start_after_string.isdigit() else None
+
         shifts = service_shifts_list_use_case(repo, shelter_id, filter_start_after)
-        
+
         return Response(
             json.dumps([shift.to_dict() for shift in shifts], cls=ServiceShiftJsonEncoder),
             mimetype='application/json',
             status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
         )
-    
+
     elif request.method == 'POST':
         shifts_as_dict = request.get_json()
-        
+
+        # Validate that the JSON payload is present
+        if not shifts_as_dict:
+            return jsonify({'error': 'Invalid JSON payload'}), 400
+
         # Convert to ServiceShift objects
-        shifts_obj = [ServiceShift.from_dict(shift) for shift in shifts_as_dict]
+        try:
+            shifts_obj = [ServiceShift.from_dict(shift) for shift in shifts_as_dict]
+        except Exception as e:
+            return jsonify({'error': f'Invalid data format: {str(e)}'}), 400
 
         add_response = shift_add_use_case(repo, shifts_obj)
         status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR]
-        
-        if add_response['success']:
+
+        if add_response.get('success'):  # Ensure 'success' exists in response
             status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
-        
+
         return Response(
             json.dumps(add_response, default=str),
             mimetype='application/json',
             status=status_code
+        )
+
+# Ensure ServiceShift class has to_dict() method
+class ServiceShift:
+    def __init__(self, id, shelter_id, start_time, end_time):
+        self.id = id
+        self.shelter_id = shelter_id
+        self.start_time = start_time
+        self.end_time = end_time
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'shelter_id': self.shelter_id,
+            'start_time': self.start_time,
+            'end_time': self.end_time
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            id=data.get('id'),
+            shelter_id=data.get('shelter_id'),
+            start_time=data.get('start_time'),
+            end_time=data.get('end_time')
         )

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -5,9 +5,11 @@ import json
 from flask import Blueprint, request, Response, jsonify
 from flask_cors import cross_origin
 from use_cases.add_service_shifts import shift_add_use_case
-from use_cases.list_service_shifts_use_case import service_shifts_list_use_case
+from use_cases.list_service_shifts_use_case import (
+    service_shifts_list_use_case,
+)
 from repository.mongo.service_shifts import ServiceShiftsMongoRepo
-from domains.service_shift import ServiceShift  # Ensure we are importing it instead of redefining
+from domains.service_shift import ServiceShift
 from application.rest.work_shift import HTTP_STATUS_CODES_MAPPING
 from responses import ResponseTypes
 from serializers.service_shift import ServiceShiftJsonEncoder
@@ -28,7 +30,9 @@ def handle_service_shift():
 
         # Convert safely
         shelter_id = (
-            int(shelter_id_str) if shelter_id_str and shelter_id_str.isdigit() else None
+            int(shelter_id_str)
+            if shelter_id_str and shelter_id_str.isdigit()
+            else None
         )
         filter_start_after = (
             int(filter_start_after_str)
@@ -36,7 +40,9 @@ def handle_service_shift():
             else None
         )
 
-        shifts = service_shifts_list_use_case(repo, shelter_id, filter_start_after)
+        shifts = service_shifts_list_use_case(
+            repo, shelter_id, filter_start_after
+        )
 
         return Response(
             json.dumps(
@@ -47,7 +53,7 @@ def handle_service_shift():
             status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS],
         )
 
-    elif request.method == "POST":
+    if request.method == "POST":
         shifts_as_dict = request.get_json()
 
         # Validate JSON payload
@@ -55,7 +61,10 @@ def handle_service_shift():
             return jsonify({"error": "Invalid JSON payload"}), 400
 
         try:
-            shifts_obj = [ServiceShift.from_dict(shift) for shift in shifts_as_dict]
+            shifts_obj = [
+                ServiceShift.from_dict(shift)
+                for shift in shifts_as_dict
+            ]
         except (KeyError, TypeError, ValueError) as err:
             return jsonify({"error": f"Invalid data format: {str(err)}"}), 400
 

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -35,7 +35,9 @@ def handle_service_shift():
             else None
         )
         filter_start_after = (
-            int(filter_start_after_str) if filter_start_after_str and filter_start_after_str.isdigit() else None
+            int(filter_start_after_str)
+            if filter_start_after_str and filter_start_after_str.isdigit()
+            else None
         )
 
         shifts = service_shifts_list_use_case(repo, shelter_id, filter_start_after)

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -7,7 +7,7 @@ from flask_cors import cross_origin
 from use_cases.add_service_shifts import shift_add_use_case
 from use_cases.list_service_shifts_use_case import service_shifts_list_use_case
 from repository.mongo.service_shifts import ServiceShiftsMongoRepo
-from domains.service_shift import ServiceShift
+from domains.service_shift import ServiceShift  # Ensure we are importing it instead of redefining
 from application.rest.work_shift import HTTP_STATUS_CODES_MAPPING
 from responses import ResponseTypes
 from serializers.service_shift import ServiceShiftJsonEncoder
@@ -23,21 +23,26 @@ def handle_service_shift():
     repo = ServiceShiftsMongoRepo()
 
     if request.method == "GET":
-        shelter_id_string = request.args.get("shelter_id")
-        filter_start_after_string = request.args.get("filter_start_after")
+        shelter_id_str = request.args.get("shelter_id")
+        filter_start_after_str = request.args.get("filter_start_after")
 
-        # Ensure proper conversion to int, handling empty or invalid cases
+        # Convert safely
         shelter_id = (
-            int(shelter_id_string) if shelter_id_string and shelter_id_string.isdigit() else None
+            int(shelter_id_str) if shelter_id_str and shelter_id_str.isdigit() else None
         )
         filter_start_after = (
-            int(filter_start_after_string) if filter_start_after_string and filter_start_after_string.isdigit() else None
+            int(filter_start_after_str)
+            if filter_start_after_str and filter_start_after_str.isdigit()
+            else None
         )
 
         shifts = service_shifts_list_use_case(repo, shelter_id, filter_start_after)
 
         return Response(
-            json.dumps([shift.to_dict() for shift in shifts], cls=ServiceShiftJsonEncoder),
+            json.dumps(
+                [shift.to_dict() for shift in shifts],
+                cls=ServiceShiftJsonEncoder,
+            ),
             mimetype="application/json",
             status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS],
         )
@@ -45,12 +50,11 @@ def handle_service_shift():
     elif request.method == "POST":
         shifts_as_dict = request.get_json()
 
-        # Validate that the JSON payload is present
+        # Validate JSON payload
         if not shifts_as_dict:
             return jsonify({"error": "Invalid JSON payload"}), 400
 
         try:
-            # Convert to ServiceShift objects
             shifts_obj = [ServiceShift.from_dict(shift) for shift in shifts_as_dict]
         except (KeyError, TypeError, ValueError) as err:
             return jsonify({"error": f"Invalid data format: {str(err)}"}), 400
@@ -58,64 +62,11 @@ def handle_service_shift():
         add_response = shift_add_use_case(repo, shifts_obj)
         status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR]
 
-        if add_response.get("success"):  # Ensure 'success' exists in response
+        if add_response.get("success"):
             status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
 
         return Response(
             json.dumps(add_response, default=str),
             mimetype="application/json",
             status=status_code,
-        )
-
-
-class ServiceShift:
-    """
-    Represents a service shift.
-    """
-
-    def __init__(self, shift_id, shelter_id, start_time, end_time):
-        """
-        Initializes a ServiceShift object.
-
-        Args:
-            shift_id (int): The unique identifier of the shift.
-            shelter_id (int): The shelter ID associated with the shift.
-            start_time (str): The start time of the shift.
-            end_time (str): The end time of the shift.
-        """
-        self.shift_id = shift_id
-        self.shelter_id = shelter_id
-        self.start_time = start_time
-        self.end_time = end_time
-
-    def to_dict(self):
-        """
-        Converts a ServiceShift object into a dictionary.
-
-        Returns:
-            dict: Dictionary representation of the service shift.
-        """
-        return {
-            "shift_id": self.shift_id,
-            "shelter_id": self.shelter_id,
-            "start_time": self.start_time,
-            "end_time": self.end_time,
-        }
-
-    @classmethod
-    def from_dict(cls, data):
-        """
-        Creates a ServiceShift object from a dictionary.
-
-        Args:
-            data (dict): Dictionary containing shift details.
-
-        Returns:
-            ServiceShift: A new instance of the ServiceShift class.
-        """
-        return cls(
-            shift_id=data.get("id"),  # Renamed from 'id' to 'shift_id' to avoid conflicts
-            shelter_id=data.get("shelter_id"),
-            start_time=data.get("start_time"),
-            end_time=data.get("end_time"),
         )

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -29,7 +29,11 @@ def handle_service_shift():
         filter_start_after_str = request.args.get("filter_start_after")
 
         # Ensure proper conversion to int, handling empty or invalid cases
-        shelter_id = int(shelter_id_str) if shelter_id_str and shelter_id_str.isdigit() else None
+        shelter_id = (
+            int(shelter_id_str)
+            if shelter_id_str and shelter_id_str.isdigit()
+            else None
+        )
         filter_start_after = (
             int(filter_start_after_str) if filter_start_after_str and filter_start_after_str.isdigit() else None
         )

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -10,6 +10,7 @@ class ServiceShiftsMongoRepo:
     """
     MongoDB repository class for managing service shifts.
     """
+
     def __init__(self):
         """
         Initialize the repository with a MongoDB connection.
@@ -28,9 +29,9 @@ class ServiceShiftsMongoRepo:
             list: A list of inserted shift IDs.
         """
         for shift in shift_data:
-            shift.pop('_id', None)  # Remove _id to let MongoDB generate it
+            shift.pop("_id", None)  # Remove _id to let MongoDB generate it
         result = self.collection.insert_many(shift_data)
-        return [str(id) for id in result.inserted_ids]
+        return [str(shift_id) for shift_id in result.inserted_ids]
 
     def check_shift_overlap(self, shelter_id, shift_start, shift_end):
         """
@@ -44,11 +45,13 @@ class ServiceShiftsMongoRepo:
         Returns:
             bool: True if there is an overlap, False otherwise.
         """
-        overlapping = self.collection.find_one({
-            'shelter_id': shelter_id,
-            'shift_start': {'$lt': shift_end},
-            'shift_end': {'$gt': shift_start}
-        })
+        overlapping = self.collection.find_one(
+            {
+                "shelter_id": shelter_id,
+                "shift_start": {"$lt": shift_end},
+                "shift_end": {"$gt": shift_start},
+            }
+        )
         return overlapping is not None
 
     def list(self, shelter_id=None, filter_start_after=None):
@@ -64,9 +67,12 @@ class ServiceShiftsMongoRepo:
         """
         db_filter = {}
         if shelter_id:
-            db_filter['shelter_id'] = shelter_id
+            db_filter["shelter_id"] = shelter_id
         if filter_start_after:
-            db_filter['shift_start'] = {'$gt': filter_start_after}
+            db_filter["shift_start"] = {"$gt": filter_start_after}
 
-        service_shifts = [ServiceShift.from_dict(i) for i in self.collection.find(db_filter)]
+        service_shifts = [
+            ServiceShift.from_dict(shift)
+            for shift in self.collection.find(db_filter)
+        ]
         return service_shifts

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -87,5 +87,5 @@ class ServiceShiftsMongoRepo:
         Returns:
             list: A list of ServiceShift objects.
         """
-        shifts = self.collection.find({'_id': {'$in': shift_ids}})
+        shifts = self.collection.find({"_id": {"$in": shift_ids}})
         return [ServiceShift.from_dict(shift) for shift in shifts]

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -1,34 +1,48 @@
 """
-This module handles Mongo database interactions with new service_shift
+This module handles MongoDB interactions with the service_shifts collection.
 """
+
 from domains.service_shift import ServiceShift
 from config.mongodb_config import get_db
 
+
 class ServiceShiftsMongoRepo:
     """
-    repo class for service shifts MongoDB operations
+    MongoDB repository class for managing service shifts.
     """
     def __init__(self):
         """
-        database connection
+        Initialize the repository with a MongoDB connection.
         """
         self.db = get_db()
         self.collection = self.db.service_shifts
 
     def add_service_shifts(self, shift_data):
         """
-        adds new service shift to the database
-        returns the new unique ID assigned to the shift
+        Adds new service shifts to the database.
+        
+        Args:
+            shift_data (list): A list of service shift dictionaries.
+        
+        Returns:
+            list: A list of inserted shift IDs.
         """
         for shift in shift_data:
-            shift.pop('_id', None)
-        self.db.service_shifts.insert_many(shift_data)
-
+            shift.pop('_id', None)  # Remove _id to let MongoDB generate it
+        result = self.collection.insert_many(shift_data)
+        return [str(id) for id in result.inserted_ids]
 
     def check_shift_overlap(self, shelter_id, shift_start, shift_end):
         """
-        checks if new shift overlaps with existing shifts for shelter
-        true if there is overlap and false otherwise
+        Checks if a new shift overlaps with an existing shift.
+        
+        Args:
+            shelter_id (int): The shelter ID.
+            shift_start (int): The start time of the new shift.
+            shift_end (int): The end time of the new shift.
+        
+        Returns:
+            bool: True if there is an overlap, False otherwise.
         """
         overlapping = self.collection.find_one({
             'shelter_id': shelter_id,
@@ -37,23 +51,22 @@ class ServiceShiftsMongoRepo:
         })
         return overlapping is not None
 
-    def list(self, shelter=None):
+    def list(self, shelter_id=None, filter_start_after=None):
         """
-        Gets all service shifts in the database
-        returns list of all shift documents
+        Retrieves service shifts, optionally filtered by shelter_id and time.
+        
+        Args:
+            shelter_id (int, optional): The ID of the shelter.
+            filter_start_after (int, optional): The minimum start time.
+        
+        Returns:
+            list: A list of service shift objects.
         """
         db_filter = {}
-        if shelter:
-            db_filter['shelter_id'] = shelter
-        service_shifts = [
-            ServiceShift.from_dict(i) for i in self.collection.find \
-            (filter=db_filter)
-        ]
-        return service_shifts
+        if shelter_id:
+            db_filter['shelter_id'] = shelter_id
+        if filter_start_after:
+            db_filter['shift_start'] = {'$gt': filter_start_after}
 
-    def get_shifts(self, shift_ids):
-        """
-        gets multiple shifts by a list of ids
-        """
-        shifts = self.collection.find({'_id': {'$in': shift_ids}})
-        return [ServiceShift.from_dict(shift) for shift in shifts]
+        service_shifts = [ServiceShift.from_dict(i) for i in self.collection.find(db_filter)]
+        return service_shifts

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -76,3 +76,16 @@ class ServiceShiftsMongoRepo:
             for shift in self.collection.find(db_filter)
         ]
         return service_shifts
+
+    def get_shifts(self, shift_ids):
+        """
+        Gets multiple shifts by a list of IDs.
+        
+        Args:
+            shift_ids (list): A list of shift IDs.
+        
+        Returns:
+            list: A list of ServiceShift objects.
+        """
+        shifts = self.collection.find({'_id': {'$in': shift_ids}})
+        return [ServiceShift.from_dict(shift) for shift in shifts]

--- a/server/use_cases/list_service_shifts_use_case.py
+++ b/server/use_cases/list_service_shifts_use_case.py
@@ -2,9 +2,16 @@
 This module contains the use case for listing shifts.
 """
 
-def service_shifts_list_use_case(repo, shelter=None):
+def service_shifts_list_use_case(repo, shelter=None, filter_start_after=None):
     """
-    The function retrieves shelters from the chosen database.
+    Retrieves service shifts, filtered by shelter and optional start time.
+
+    Args:
+        repo: The repository for accessing service shifts.
+        shelter (int, optional): The ID of the shelter.
+        filter_start_after (int, optional): The minimum start time.
+
+    Returns:
+        list: A list of service shift records.
     """
-    list_service_shifts = repo.list(shelter)
-    return list_service_shifts
+    return repo.list(shelter, filter_start_after)


### PR DESCRIPTION
Fixes #176

**What was changed?**

Updated the GET /service_shift API to support time filtering (filter_start_after).
Modified the MongoDB repository to handle time-based queries for service shifts.
Adjusted the Flask route in service_shifts.py to accept the new filter parameter.

**Why was it changed?**

The API needed to support retrieving shifts that occur after a specific timestamp.
This enables the Shelter Dashboard and Volunteer Dashboard to fetch only upcoming shifts.

**How was it changed?**

Modified server/repository/mongo/service_shifts.py
Added a filter_start_after parameter to query shifts by start time.
Updated server/application/rest/service_shifts.py
Extracted filter_start_after from request args.
Passed it to the service_shifts_list_use_case.

**Screenshots that show the changes (if applicable):**
