### PR TITLE
updated useShelterData.js to get from /shelter instead of GetHelp

### DIFF
--- a/client_app/src/components/volunteer/hooks/useShelterData.js
+++ b/client_app/src/components/volunteer/hooks/useShelterData.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { GETHELP_API } from '../../../config';
+//import { GETHELP_API } from '../../../config';
+import { SERVER } from '../../../config';
 import ShiftsData from "../ShiftsData";
 
 export const useShelterData = (defaultRadius) => {
@@ -17,7 +18,7 @@ export const useShelterData = (defaultRadius) => {
 
   const fetchData = () => {
     setLoading(true);
-    const newEndpoint = `${GETHELP_API}v2/facilities?page=0&pageSize=1000&latitude=${latitude}&longitude=${longitude}&radius=${radius}`;
+    const newEndpoint = `${SERVER}/shelter`;
     
     fetch(newEndpoint, {
       method: "GET",
@@ -25,10 +26,10 @@ export const useShelterData = (defaultRadius) => {
     })
       .then(response => response.json())
       // uncomment this when we switch to using our /shelter API endpoint
-      // .then(data => {
-      //   setOriginalData(data.content);
-      //   setLoading(false);
-      // })
+       .then(data => {
+         setOriginalData(data.content);
+         setLoading(false);
+       })
       .catch(error => console.log(error));
   };
 


### PR DESCRIPTION
Fixes #184 

**What was changed?**

Updated the Volunteer Dashboard to retrieve shelter data from our own API (GET /shelter) instead of calling the GetHelp API. Modified the `useShelterData.js` file to fetch shelters from ${SERVER}/shelter. Removed references to the GetHelp API that were no longer needed.

**Why was it changed?**

Previously, shelter data was being retrieved from GetHelp API, which was not ideal anymore. After Issue #182 was resolved, shelters are stored in our own database. This change ensures that shelters stored in our system are properly displayed in the Volunteer Dashboard.

**How was it changed?**

Replaced the old API call `${GETHELP_API}...` with the new API call, `${SERVER}/shelter`. Imported SERVER from `config.js` to ensure the correct API is being used. Uncommented some previously commented out code, which processes the API response and updates the UI with shelter data.