### PR TITLE
Add test coverage for shift_add_use_case function

### DIFF
--- a/server/tests/use_cases/test_add_service_shifts.py
+++ b/server/tests/use_cases/test_add_service_shifts.py
@@ -77,3 +77,18 @@ def test_add_exact_duplicate_shift(mock_repo):
 
     assert result["success"] == "false"
     assert result["message"] == "overlapping shift"
+
+def test_add_overlapping_shifts_case1(mock_repo):
+    """
+    Test: Overlapping shifts (START_TIME1 < START_TIME2 < END_TIME2 < END_TIME1).
+    Expected: Should be rejected.
+    """
+    shift1 = ServiceShift(shelter_id=1, shift_start=1730605200000, shift_end=1730616000000)  # 09:00 AM - 12:00 PM
+    shift2 = ServiceShift(shelter_id=1, shift_start=1730608800000, shift_end=1730619600000)  # 10:00 AM - 01:00 PM
+
+    print("\n Adding overlapping shifts (Case 1)...")
+    result = shift_add_use_case(mock_repo, [shift1, shift2])
+    print(" Result:", result)
+
+    assert result["success"] == "false"
+    assert result["message"] == "overlapping shift"

--- a/server/tests/use_cases/test_add_service_shifts.py
+++ b/server/tests/use_cases/test_add_service_shifts.py
@@ -92,3 +92,19 @@ def test_add_overlapping_shifts_case1(mock_repo):
 
     assert result["success"] == "false"
     assert result["message"] == "overlapping shift"
+
+def test_add_overlapping_shifts_case2(mock_repo):
+    """
+    Test: Overlapping shifts (START_TIME1 < START_TIME2 < END_TIME1 < END_TIME2).
+    Expected: Should be rejected.
+    """
+    shift1 = ServiceShift(shelter_id=1, shift_start=1730605200000, shift_end=1730612400000)  # 09:00 AM - 11:00 AM
+    shift2 = ServiceShift(shelter_id=1, shift_start=1730608800000, shift_end=1730616000000)  # 10:00 AM - 12:00 PM
+
+    print("\n Adding overlapping shifts (Case 2)...")
+    result = shift_add_use_case(mock_repo, [shift1, shift2])
+    print(" Result:", result)
+
+    assert result["success"] == "false"
+    assert result["message"] == "overlapping shift"
+

--- a/server/tests/use_cases/test_add_service_shifts.py
+++ b/server/tests/use_cases/test_add_service_shifts.py
@@ -1,5 +1,4 @@
 import pytest
-from datetime import datetime, timedelta
 from server.use_cases.add_service_shifts import shift_add_use_case
 from server.domains.service_shift import ServiceShift
 
@@ -45,8 +44,9 @@ def test_add_non_overlapping_shifts(mock_repo):
     result = shift_add_use_case(mock_repo, [shift1, shift2])
     print(" Result:", result)
 
-    assert result["success"] is True
+    assert result["success"] == True
     assert len(result["service_shift_ids"]) == 2
+
 
 def test_add_shifts_same_time_different_shelters(mock_repo):
     """
@@ -60,8 +60,9 @@ def test_add_shifts_same_time_different_shelters(mock_repo):
     result = shift_add_use_case(mock_repo, [shift1, shift2])
     print(" Result:", result)
 
-    assert result["success"] is True
+    assert result["success"] == True
     assert len(result["service_shift_ids"]) == 2
+
 
 def test_add_exact_duplicate_shift(mock_repo):
     """
@@ -78,6 +79,7 @@ def test_add_exact_duplicate_shift(mock_repo):
     assert result["success"] == "false"
     assert result["message"] == "overlapping shift"
 
+
 def test_add_overlapping_shifts_case1(mock_repo):
     """
     Test: Overlapping shifts (START_TIME1 < START_TIME2 < END_TIME2 < END_TIME1).
@@ -93,6 +95,7 @@ def test_add_overlapping_shifts_case1(mock_repo):
     assert result["success"] == "false"
     assert result["message"] == "overlapping shift"
 
+
 def test_add_overlapping_shifts_case2(mock_repo):
     """
     Test: Overlapping shifts (START_TIME1 < START_TIME2 < END_TIME1 < END_TIME2).
@@ -107,7 +110,8 @@ def test_add_overlapping_shifts_case2(mock_repo):
 
     assert result["success"] == "false"
     assert result["message"] == "overlapping shift"
-    
+
+
 def test_add_shift_conflicting_with_existing_shift(mock_repo):
     """
     Test: Adding a shift that conflicts with an existing shift in the database.
@@ -128,4 +132,4 @@ def test_add_shift_conflicting_with_existing_shift(mock_repo):
 
     assert result["success"] == "false"
     assert result["message"] == "overlapping shift"
-
+    

--- a/server/tests/use_cases/test_add_service_shifts.py
+++ b/server/tests/use_cases/test_add_service_shifts.py
@@ -47,3 +47,18 @@ def test_add_non_overlapping_shifts(mock_repo):
 
     assert result["success"] is True
     assert len(result["service_shift_ids"]) == 2
+
+def test_add_shifts_same_time_different_shelters(mock_repo):
+    """
+    Test: Two shifts at the same time but for different shelters.
+    Expected: Both should be added.
+    """
+    shift1 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 2, 10, 0), shift_end=datetime(2025, 3, 2, 12, 0))
+    shift2 = ServiceShift(shelter_id=2, shift_start=datetime(2025, 3, 2, 10, 0), shift_end=datetime(2025, 3, 2, 12, 0))
+
+    print("\n Adding shifts at the same time for different shelters...")
+    result = shift_add_use_case(mock_repo, [shift1, shift2])
+    print(" Result:", result)
+
+    assert result["success"] is True
+    assert len(result["service_shift_ids"]) == 2

--- a/server/tests/use_cases/test_add_service_shifts.py
+++ b/server/tests/use_cases/test_add_service_shifts.py
@@ -1,0 +1,49 @@
+import pytest
+from datetime import datetime, timedelta
+from server.use_cases.add_service_shifts import shift_add_use_case
+from server.domains.service_shift import ServiceShift
+
+
+class MockShiftRepository:
+    """
+    Mock repository to simulate database operations.
+    """
+    def __init__(self):
+        self.shifts = []
+
+    def check_shift_overlap(self, shelter_id, shift_start, shift_end):
+        """
+        Simulates checking for overlapping shifts in the database.
+        """
+        for shift in self.shifts:
+            if shift["shelter_id"] == shelter_id and \
+               max(shift["shift_start"], shift_start) < min(shift["shift_end"], shift_end):
+                return True  # Overlap detected
+        return False
+
+    def add_service_shifts(self, shift_dicts):
+        """
+        Simulates adding shifts to the database.
+        """
+        self.shifts.extend(shift_dicts)
+
+
+@pytest.fixture
+def mock_repo():
+    return MockShiftRepository()
+
+
+def test_add_non_overlapping_shifts(mock_repo):
+    """
+    Test: Two shifts for the same shelter, no overlap.
+    Expected: Both should be added.
+    """
+    shift1 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 1, 9, 0), shift_end=datetime(2025, 3, 1, 12, 0))
+    shift2 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 1, 13, 0), shift_end=datetime(2025, 3, 1, 16, 0))
+
+    print("\n Adding non-overlapping shifts for the same shelter...")
+    result = shift_add_use_case(mock_repo, [shift1, shift2])
+    print(" Result:", result)
+
+    assert result["success"] is True
+    assert len(result["service_shift_ids"]) == 2

--- a/server/tests/use_cases/test_add_service_shifts.py
+++ b/server/tests/use_cases/test_add_service_shifts.py
@@ -62,3 +62,18 @@ def test_add_shifts_same_time_different_shelters(mock_repo):
 
     assert result["success"] is True
     assert len(result["service_shift_ids"]) == 2
+
+def test_add_exact_duplicate_shift(mock_repo):
+    """
+    Test: Adding the same shift twice for the same shelter.
+    Expected: Should be rejected.
+    """
+    shift1 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 4, 14, 0), shift_end=datetime(2025, 3, 4, 18, 0))
+    shift2 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 4, 14, 0), shift_end=datetime(2025, 3, 4, 18, 0))
+
+    print("\n Adding duplicate shift for the same shelter...")
+    result = shift_add_use_case(mock_repo, [shift1, shift2])
+    print("Result:", result)
+
+    assert result["success"] == "false"
+    assert result["message"] == "overlapping shift"

--- a/server/tests/use_cases/test_add_service_shifts.py
+++ b/server/tests/use_cases/test_add_service_shifts.py
@@ -38,8 +38,8 @@ def test_add_non_overlapping_shifts(mock_repo):
     Test: Two shifts for the same shelter, no overlap.
     Expected: Both should be added.
     """
-    shift1 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 1, 9, 0), shift_end=datetime(2025, 3, 1, 12, 0))
-    shift2 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 1, 13, 0), shift_end=datetime(2025, 3, 1, 16, 0))
+    shift1 = ServiceShift(shelter_id=1, shift_start=1730432400000, shift_end=1730443200000)  # 09:00 AM - 12:00 PM
+    shift2 = ServiceShift(shelter_id=1, shift_start=1730446800000, shift_end=1730457600000)  # 01:00 PM - 04:00 PM
 
     print("\n Adding non-overlapping shifts for the same shelter...")
     result = shift_add_use_case(mock_repo, [shift1, shift2])
@@ -53,8 +53,8 @@ def test_add_shifts_same_time_different_shelters(mock_repo):
     Test: Two shifts at the same time but for different shelters.
     Expected: Both should be added.
     """
-    shift1 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 2, 10, 0), shift_end=datetime(2025, 3, 2, 12, 0))
-    shift2 = ServiceShift(shelter_id=2, shift_start=datetime(2025, 3, 2, 10, 0), shift_end=datetime(2025, 3, 2, 12, 0))
+    shift1 = ServiceShift(shelter_id=1, shift_start=1730518800000, shift_end=1730526000000)  # 10:00 AM - 12:00 PM
+    shift2 = ServiceShift(shelter_id=2, shift_start=1730518800000, shift_end=1730526000000)  # 10:00 AM - 12:00 PM
 
     print("\n Adding shifts at the same time for different shelters...")
     result = shift_add_use_case(mock_repo, [shift1, shift2])
@@ -68,8 +68,8 @@ def test_add_exact_duplicate_shift(mock_repo):
     Test: Adding the same shift twice for the same shelter.
     Expected: Should be rejected.
     """
-    shift1 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 4, 14, 0), shift_end=datetime(2025, 3, 4, 18, 0))
-    shift2 = ServiceShift(shelter_id=1, shift_start=datetime(2025, 3, 4, 14, 0), shift_end=datetime(2025, 3, 4, 18, 0))
+    shift1 = ServiceShift(shelter_id=1, shift_start=1730691600000, shift_end=1730706000000)  # 02:00 PM - 06:00 PM
+    shift2 = ServiceShift(shelter_id=1, shift_start=1730691600000, shift_end=1730706000000)  # 02:00 PM - 06:00 PM
 
     print("\n Adding duplicate shift for the same shelter...")
     result = shift_add_use_case(mock_repo, [shift1, shift2])

--- a/server/tests/use_cases/test_add_service_shifts.py
+++ b/server/tests/use_cases/test_add_service_shifts.py
@@ -107,4 +107,25 @@ def test_add_overlapping_shifts_case2(mock_repo):
 
     assert result["success"] == "false"
     assert result["message"] == "overlapping shift"
+    
+def test_add_shift_conflicting_with_existing_shift(mock_repo):
+    """
+    Test: Adding a shift that conflicts with an existing shift in the database.
+    Expected: Should be rejected.
+    """
+    existing_shift = {
+        "shelter_id": 1,
+        "shift_start": 1730785200000,  # 10:00 AM
+        "shift_end": 1730803200000     # 02:00 PM
+    }
+    mock_repo.shifts.append(existing_shift)
+
+    new_shift = ServiceShift(shelter_id=1, shift_start=1730788800000, shift_end=1730796000000)  # 11:00 AM - 01:00 PM
+
+    print("\nAdding a shift that conflicts with an existing shift in DB...")
+    result = shift_add_use_case(mock_repo, [new_shift])
+    print(" Result:", result)
+
+    assert result["success"] == "false"
+    assert result["message"] == "overlapping shift"
 


### PR DESCRIPTION
Fixes #195 

**What was changed?**

*- Added automated test cases for the shift_add_use_case function in server/tests/use_cases/test_add_service_shifts.py
- Implemented tests to validate shift addition behavior for both overlapping and non-overlapping cases.*

**How was it changed?**

*Created test_add_service_shifts.py under server/tests/use_cases/

Test cases added:

✅ Adding non-overlapping shifts for the same shelter (@Gayatrinj)
✅ Adding shifts at the same time but for different shelters (@Gayatrinj)
✅ Adding duplicate shifts for the same shelter (@Gayatrinj)
✅ Adding overlapping shifts (Case 1) where shift times partially overlap (@Sarvesh-7777)
✅ Adding overlapping shifts (Case 2) where a shift completely overlaps another (@Sarvesh-7777)
✅ Adding a shift that conflicts with an existing shift in the database (@Sarvesh-7777)
Adjusted shift start and end times to milliseconds for consistency with other tests in the repository.*

 print statements to run tests cleanly using:
*python -m pytest server/tests/use_cases/test_add_service_shifts.py*
To execute the test cases without excessive output, run:
pytest server/tests/use_cases/test_add_service_shifts.py
**Screenshots that show the changes:**
![image](https://github.com/user-attachments/assets/d64e7e6b-880f-4f3c-8fdf-6ba4a2287c8b)
![image](https://github.com/user-attachments/assets/3a89ebfc-d145-495b-9161-363b00a09349)
