### PR TITLE
Fixed access to mongo repo for shelter resources

### DIFF
--- a/server/application/rest/shelter.py
+++ b/server/application/rest/shelter.py
@@ -23,8 +23,7 @@ def shelter():
     On GET: The function returns a list of all shelters in the system.
     On POST: The function adds a shelter to the system.
     """
-    db_config = db_configuration()
-    repo = ShelterRepo(db_config[0], db_config[1])
+    repo = ShelterRepo()
 
     # add user authentication and authorization logic here
 

--- a/server/application/rest/shelter.py
+++ b/server/application/rest/shelter.py
@@ -9,7 +9,6 @@ from repository.mongo.shelter import ShelterRepo
 from use_cases.shelters.add_shelter_use_case import shelter_add_use_case
 from use_cases.shelters.list_shelters_use_case import shelter_list_use_case
 from application.rest.work_shift import HTTP_STATUS_CODES_MAPPING
-from application.rest.work_shift import db_configuration
 from domains.shelter.shelter import Shelter
 from serializers.shelter import ShelterJsonEncoder
 from responses import ResponseTypes

--- a/server/repository/mongo/shelter.py
+++ b/server/repository/mongo/shelter.py
@@ -1,7 +1,7 @@
 """
 Module handles the mongo DB operations for shelter related data
 """
-import pymongo
+from config.mongodb_config import get_db
 from domains.shelter.shelter import Shelter
 from bson.objectid import ObjectId
 
@@ -9,12 +9,11 @@ class ShelterRepo:
     """
     A mongo repository for storing work shifts.
     """
-    def __init__(self, uri, database):
+    def __init__(self):
         """
         Initialize the repo with passed data.
         """
-        client = pymongo.MongoClient(uri)
-        self.db = client[database]
+        self.db = get_db()
         self.collection = self.db.shelters
 
     def _create_shelter_objects(self, results):

--- a/server/tests/rest/shelter/test_shelter.py
+++ b/server/tests/rest/shelter/test_shelter.py
@@ -26,11 +26,7 @@ def client():
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
 @patch("application.rest.shelter.shelter_add_use_case")
-@patch(
-    "application.rest.shelter.db_configuration",
-    return_value=("mongodb://mock_uri", "mock_db"),
-)
-def test_post_shelter(mock_db_config, mock_shelter_add_use_case, client):
+def test_post_shelter(mock_shelter_add_use_case, client):
     mock_response = {
         "id": "SOME_ID",
         "success": True,
@@ -62,11 +58,7 @@ def test_post_shelter(mock_db_config, mock_shelter_add_use_case, client):
 
 
 @patch("application.rest.shelter.shelter_list_use_case")
-@patch(
-    "application.rest.shelter.db_configuration",
-    return_value=("mongodb://mock_uri", "mock_db"),
-)
-def test_get_shelter(mock_db_config, mock_shelter_list_use_case, client):
+def test_get_shelter(mock_shelter_list_use_case, client):
     mock_shelters = [
         Shelter(
             name="Shelter One",


### PR DESCRIPTION
When issue #182 was resolved, the access to mongo repo for the shelter resources in `repository/mongo/shelter.py` was done inconsistently with other resources. For configuring db to access other resources, we call `config/mongodb_config/get_db()` to get configuration information. However, in `repository/mongo/shelter.py`, we were configuring the connection within that module, instead of calling `get_db()`. This inconsistency resulted in problems accessing the database hosted on mongodb atlas.
