### PR TITLE
Command line interface for creating system and shelter admins

### DIFF
--- a/server/cli/admin_cli.py
+++ b/server/cli/admin_cli.py
@@ -1,5 +1,6 @@
 import argparse
 from use_cases.authorization.add_system_admin import add_system_admin
+from use_cases.authorization.add_shelter_admin import add_shelter_admin
 from repository.mongo.authorization import PermissionsMongoRepo
 from responses import ResponseTypes
 
@@ -14,12 +15,34 @@ def create_system_admin(email):
     except Exception as e:
         print(f"Failed to grant system admin permissions: {e}")
 
+def create_shelter_admin(email, shelter_id):
+    permissions_repo = PermissionsMongoRepo()
+    try:
+        response = add_shelter_admin(permissions_repo, shelter_id, email)
+        if response.response_type == ResponseTypes.SUCCESS:
+            print(f"Shelter admin permissions granted to {email} for shelter {shelter_id}")
+        else:
+            print(response.value)
+    except Exception as e:
+        print(f"Failed to grant shelter admin permissions: {e}")
+
 def main():
-    parser = argparse.ArgumentParser(description='Create a system admin by email address.')
-    parser.add_argument('email', type=str, help='The email address of the user to be granted system admin permissions')
+    parser = argparse.ArgumentParser(description='Create a system admin or shelter admin by email address.')
+    subparsers = parser.add_subparsers(dest='admin_type', required=True, help='Type of admin to create')
+
+    system_admin_parser = subparsers.add_parser('system', help='Create a system admin')
+    system_admin_parser.add_argument('email', type=str, help='The email address of the user to be granted system admin permissions')
+
+    shelter_admin_parser = subparsers.add_parser('shelter', help='Create a shelter admin')
+    shelter_admin_parser.add_argument('email', type=str, help='The email address of the user to be granted shelter admin permissions')
+    shelter_admin_parser.add_argument('shelter_id', type=str, help='The ID of the shelter')
+
     args = parser.parse_args()
-    
-    create_system_admin(args.email)
+
+    if args.admin_type == 'system':
+        create_system_admin(args.email)
+    elif args.admin_type == 'shelter':
+        create_shelter_admin(args.email, args.shelter_id)
 
 if __name__ == "__main__":
     main()

--- a/server/cli/admin_cli.py
+++ b/server/cli/admin_cli.py
@@ -1,0 +1,25 @@
+import argparse
+from use_cases.authorization.add_system_admin import add_system_admin
+from repository.mongo.authorization import PermissionsMongoRepo
+from responses import ResponseTypes
+
+def create_system_admin(email):
+    permissions_repo = PermissionsMongoRepo()
+    try:
+        response = add_system_admin(permissions_repo, email)
+        if response.response_type == ResponseTypes.SUCCESS:
+            print(f"System admin permissions granted to {email}")
+        else:
+            print(response.value)
+    except Exception as e:
+        print(f"Failed to grant system admin permissions: {e}")
+
+def main():
+    parser = argparse.ArgumentParser(description='Create a system admin by email address.')
+    parser.add_argument('email', type=str, help='The email address of the user to be granted system admin permissions')
+    args = parser.parse_args()
+    
+    create_system_admin(args.email)
+
+if __name__ == "__main__":
+    main()

--- a/server/cli/admin_cli.py
+++ b/server/cli/admin_cli.py
@@ -5,7 +5,6 @@ import argparse
 from use_cases.authorization.add_system_admin import add_system_admin
 from use_cases.authorization.add_shelter_admin import add_shelter_admin
 from repository.mongo.authorization import PermissionsMongoRepo
-from responses import ResponseTypes
 
 def create_system_admin(email):
     permissions_repo = PermissionsMongoRepo()

--- a/server/cli/admin_cli.py
+++ b/server/cli/admin_cli.py
@@ -1,3 +1,6 @@
+"""
+This script is used to create system and shelter admins from the command line.
+"""
 import argparse
 from use_cases.authorization.add_system_admin import add_system_admin
 from use_cases.authorization.add_shelter_admin import add_shelter_admin
@@ -6,36 +9,53 @@ from responses import ResponseTypes
 
 def create_system_admin(email):
     permissions_repo = PermissionsMongoRepo()
-    try:
-        response = add_system_admin(permissions_repo, email)
-        if response.response_type == ResponseTypes.SUCCESS:
-            print(f"System admin permissions granted to {email}")
-        else:
-            print(response.value)
-    except Exception as e:
-        print(f"Failed to grant system admin permissions: {e}")
+    response = add_system_admin(permissions_repo, email)
+    if response.response_type == ResponseTypes.SUCCESS:
+        print(f"System admin permissions granted to {email}")
+    else:
+        print(response.value)
+
 
 def create_shelter_admin(email, shelter_id):
     permissions_repo = PermissionsMongoRepo()
-    try:
-        response = add_shelter_admin(permissions_repo, shelter_id, email)
-        if response.response_type == ResponseTypes.SUCCESS:
-            print(f"Shelter admin permissions granted to {email} for shelter {shelter_id}")
-        else:
-            print(response.value)
-    except Exception as e:
-        print(f"Failed to grant shelter admin permissions: {e}")
+    response = add_shelter_admin(permissions_repo, shelter_id, email)
+    if response.response_type == ResponseTypes.SUCCESS:
+        print(f"Shelter admin permissions granted to {email} for shelter {shelter_id}")
+    else:
+        print(response.value)
 
 def main():
-    parser = argparse.ArgumentParser(description='Create a system admin or shelter admin by email address.')
-    subparsers = parser.add_subparsers(dest='admin_type', required=True, help='Type of admin to create')
+    parser = argparse.ArgumentParser(
+        description='Create a system admin or shelter admin by email address.'
+        )
+    subparsers = parser.add_subparsers(
+        dest='admin_type',
+        required=True, help='Type of admin to create'
+        )
 
-    system_admin_parser = subparsers.add_parser('system', help='Create a system admin')
-    system_admin_parser.add_argument('email', type=str, help='The email address of the user to be granted system admin permissions')
+    system_admin_parser = subparsers.add_parser(
+        'system',
+        help='Create a system admin'
+        )
+    system_admin_parser.add_argument(
+        'email',
+        type=str,
+        help='The email address of the user to be granted system admin permissions'
+        )
 
-    shelter_admin_parser = subparsers.add_parser('shelter', help='Create a shelter admin')
-    shelter_admin_parser.add_argument('email', type=str, help='The email address of the user to be granted shelter admin permissions')
-    shelter_admin_parser.add_argument('shelter_id', type=str, help='The ID of the shelter')
+    shelter_admin_parser = subparsers.add_parser(
+        'shelter',
+        help='Create a shelter admin'
+        )
+    shelter_admin_parser.add_argument(
+        'email',
+        type=str,
+        help='The email address of the user to be granted shelter admin permissions'
+        )
+    shelter_admin_parser.add_argument(
+        'shelter_id',
+        type=str, help='The ID of the shelter'
+        )
 
     args = parser.parse_args()
 

--- a/server/cli/admin_cli.py
+++ b/server/cli/admin_cli.py
@@ -10,19 +10,13 @@ from responses import ResponseTypes
 def create_system_admin(email):
     permissions_repo = PermissionsMongoRepo()
     response = add_system_admin(permissions_repo, email)
-    if response.response_type == ResponseTypes.SUCCESS:
-        print(f"System admin permissions granted to {email}")
-    else:
-        print(response.value)
+    print(response.value)
 
 
 def create_shelter_admin(email, shelter_id):
     permissions_repo = PermissionsMongoRepo()
     response = add_shelter_admin(permissions_repo, shelter_id, email)
-    if response.response_type == ResponseTypes.SUCCESS:
-        print(f"Shelter admin permissions granted to {email} for shelter {shelter_id}")
-    else:
-        print(response.value)
+    print(response.value)
 
 def main():
     parser = argparse.ArgumentParser(
@@ -40,7 +34,8 @@ def main():
     system_admin_parser.add_argument(
         'email',
         type=str,
-        help='The email address of the user to be granted system admin permissions'
+        help='The email address of the user to be granted system admin '
+             'permissions'
         )
 
     shelter_admin_parser = subparsers.add_parser(
@@ -50,7 +45,8 @@ def main():
     shelter_admin_parser.add_argument(
         'email',
         type=str,
-        help='The email address of the user to be granted shelter admin permissions'
+        help='The email address of the user to be granted shelter admin '
+             'permissions'
         )
     shelter_admin_parser.add_argument(
         'shelter_id',
@@ -64,5 +60,5 @@ def main():
     elif args.admin_type == 'shelter':
         create_shelter_admin(args.email, args.shelter_id)
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION

**What was changed?**

Since our system now supports different roles: system admin, shelter admin, and volunteer, we need to have a way to add users with specific roles. A system admin or a shelter admin can add shelter admins through the POST /permission API endpoint. A system admin can add another system admin through the POST /permission API endpoint. However, there isn't a way to create a first system admin. To support this, I added command line interface application. Through this application we can:
1. Create a system admin
2. Create a shelter admin for a specific shelter

To run this application, first set the FLASK_ENV environment variable to "pre-production" (if connecting to the Mongodb Atlas).
export FLASK_ENV="pre-production"
Then from the server directory, run:
`python cli/admin_cli.py -h`
This will provide information about how to use the cli.
To add a system admin, run: 
`python cli/admin_cli.py system <EMAIL>`
(replace <EMAIL> with the email address for the system admin)
To add a shelter admin, run:
`python cli/admin_cli.py shelter <EMAIL> <SHELTER_ID>`
(replace <EMAIL> with the email address for the shelter admin and <SHELTER_ID> with the id of the shelter you want this user to manage)

**Why was it changed?**

This tool will be used internally for testing and to create the first system admin.