### PR TITLE
progress on ShelterID Datatype fix

### DIFF
--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -42,7 +42,7 @@ def handle_service_shift():
 
         shifts = service_shifts_list_use_case(
             repo,
-            shelter_id=shelter_id,
+            shelter_id,
             filter_start_after=filter_start_after
         )
 

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -41,7 +41,7 @@ def handle_service_shift():
         )
 
         shifts = service_shifts_list_use_case(
-            repo, 
+            repo,
             shelter_id=shelter_id,
             filter_start_after=filter_start_after
         )

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -15,7 +15,6 @@ from serializers.service_shift import ServiceShiftJsonEncoder
 
 service_shift_bp = Blueprint("service_shift", __name__)
 
-
 @service_shift_bp.route("/service_shift", methods=["GET", "POST"])
 @cross_origin()
 def handle_service_shift():
@@ -43,7 +42,7 @@ def handle_service_shift():
 
         shifts = service_shifts_list_use_case(
             repo, 
-            shelter_id=shelter_id, 
+            shelter_id=shelter_id,
             filter_start_after=filter_start_after
         )
 

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -29,11 +29,12 @@ def handle_service_shift():
         filter_start_after_str = request.args.get("filter_start_after")
 
         # Ensure proper conversion to int, handling empty or invalid cases
-        shelter_id = (
-            int(shelter_id_str)
-            if shelter_id_str and shelter_id_str.isdigit()
-            else None
-        )
+        # shelter_id = (
+        #     int(shelter_id_str)
+        #     if shelter_id_str and shelter_id_str.isdigit()
+        #     else None
+        # )
+        shelter_id = shelter_id_str
         filter_start_after = (
             int(filter_start_after_str)
             if filter_start_after_str and filter_start_after_str.isdigit()

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -42,7 +42,9 @@ def handle_service_shift():
         )
 
         shifts = service_shifts_list_use_case(
-            repo, shelter_id, filter_start_after
+            repo, 
+            shelter_id=shelter_id, 
+            filter_start_after=filter_start_after
         )
 
         return Response(

--- a/server/domains/service_shift.py
+++ b/server/domains/service_shift.py
@@ -11,7 +11,7 @@ class ServiceShift:
     """
     Data class for work shift-related data.
     """
-    shelter_id: int
+    shelter_id: str
     shift_start: int  # Number of milliseconds since the Epoch in UTC
     shift_end: int
     shift_name: str = 'Default Shift'

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -81,7 +81,7 @@ class TestServiceShiftAPI(unittest.TestCase):
                 "shift_name": "Default Shift"
             }
         ]
-        mock_list_use_case.return_value = [ServiceShift.from_dict(shift) for shift in expected_shifts]
+        mock_list_use_case.return_value = [ServiceShift.from_dict(expected_shifts)]
 
         # Act: Send GET request.
         response = self.client.get("/service_shift")

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -81,7 +81,7 @@ class TestServiceShiftAPI(unittest.TestCase):
                 "shift_name": "Default Shift"
             }
         ]
-        mock_list_use_case.return_value = [ServiceShift.from_dict(shift) 
+        mock_list_use_case.return_value = [ServiceShift.from_dict(shift)
                                            for shift in expected_shifts]
 
         # Act: Send GET request.

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -81,7 +81,8 @@ class TestServiceShiftAPI(unittest.TestCase):
                 "shift_name": "Default Shift"
             }
         ]
-        mock_list_use_case.return_value = [ServiceShift.from_dict(shift) for shift in expected_shifts]
+        mock_list_use_case.return_value = [ServiceShift.from_dict(shift) 
+                                           for shift in expected_shifts]
 
         # Act: Send GET request.
         response = self.client.get("/service_shift")
@@ -113,7 +114,8 @@ class TestServiceShiftAPI(unittest.TestCase):
           "can_sign_up": True,
           "shift_name": "Default Shift"
         }
-        mock_list_use_case.return_value = [ServiceShift.from_dict(expected_shift)]
+        mock_list_use_case.return_value = [ServiceShift.from_dict(
+            expected_shift)]
 
         # Act: Send GET request with shelter_id filter
         response = self.client.get(

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -115,13 +115,13 @@ class TestServiceShiftAPI(unittest.TestCase):
         mock_list_use_case.return_value = [expected_shift]
 
         # Act: Send GET request with shelter_id filter
-        response = self.client.get(f"/service_shift?shelter_id={test_shelter_id}")
+        response = self.client.get(
+            f"/service_shift?shelter_id={test_shelter_id}")
 
         # Parse response data
         data_str = response.get_data(as_text=True)
         json_strings = re.findall(r"\{.*?\}", data_str)
         parsed_objects = [json.loads(s) for s in json_strings]
-  
         # Assert: Verify the response contains only the filtered shift
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(parsed_objects), 1)

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -32,8 +32,8 @@ class TestServiceShiftAPI(unittest.TestCase):
 
         # Define the POST request payload.
         payload = [
-            {"shelter_id": 12345, "shift_start": 10, "shift_end": 20},
-            {"shelter_id": 12345, "shift_start": 100, "shift_end": 200}
+            {"shelter_id": "12345", "shift_start": 10, "shift_end": 20},
+            {"shelter_id": "12345", "shift_start": 100, "shift_end": 200}
         ]
         headers = {
             "Authorization": "1234567890-developer-token",
@@ -61,7 +61,7 @@ class TestServiceShiftAPI(unittest.TestCase):
         expected_shifts = [
             {
                 "_id": 201,
-                "shelter_id": 1111,
+                "shelter_id": "1111",
                 "shift_start": 10,
                 "shift_end": 20,
                 "required_volunteer_count": 1,
@@ -97,6 +97,41 @@ class TestServiceShiftAPI(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(parsed_objects, expected_shifts)
         mock_list_use_case.assert_called_once()
+
+    @patch("application.rest.service_shifts.service_shifts_list_use_case")
+    def test_get_service_shift_with_shelter_id_filter(self, mock_list_use_case):
+      # Arrange: Define the expected shift for a specific shelter
+      test_shelter_id = "ID1"
+      expected_shift = {
+        "_id": 301,
+        "shelter_id": test_shelter_id,
+        "shift_start": 10,
+        "shift_end": 20,
+        "required_volunteer_count": 1,
+        "max_volunteer_count": 5,
+        "can_sign_up": True,
+        "shift_name": "Default Shift"
+      }
+      mock_list_use_case.return_value = [expected_shift]
+
+       # Act: Send GET request with shelter_id filter
+      response = self.client.get(f"/service_shift?shelter_id={test_shelter_id}")
+
+      # Parse response data
+      data_str = response.get_data(as_text=True)
+      json_strings = re.findall(r"\{.*?\}", data_str)
+      parsed_objects = [json.loads(s) for s in json_strings]
+
+      # Assert: Verify the response contains only the filtered shift
+      self.assertEqual(response.status_code, 200)
+      self.assertEqual(len(parsed_objects), 1)
+      self.assertEqual(parsed_objects[0]["shelter_id"], test_shelter_id)
+      # Verify the use case was called with the correct shelter_id
+      mock_list_use_case.assert_called_once()
+      # Extract the args that the mock was called with
+      _, kwargs = mock_list_use_case.call_args
+      self.assertEqual(kwargs.get("shelter_id"), test_shelter_id)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -71,7 +71,7 @@ class TestServiceShiftAPI(unittest.TestCase):
             },
             {
                 "_id": 202,
-                "shelter_id": 2222,
+                "shelter_id": "2222",
                 "shift_start": 10,
                 "shift_end": 20,
                 "required_volunteer_count": 1,

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -81,7 +81,7 @@ class TestServiceShiftAPI(unittest.TestCase):
                 "shift_name": "Default Shift"
             }
         ]
-        mock_list_use_case.return_value = [ServiceShift.from_dict(expected_shift)]
+        mock_list_use_case.return_value = [ServiceShift.from_dict(shift) for shift in expected_shifts]
 
         # Act: Send GET request.
         response = self.client.get("/service_shift")
@@ -113,7 +113,7 @@ class TestServiceShiftAPI(unittest.TestCase):
           "can_sign_up": True,
           "shift_name": "Default Shift"
         }
-        mock_list_use_case.return_value = [expected_shift]
+        mock_list_use_case.return_value = [ServiceShift.from_dict(expected_shift)]
 
         # Act: Send GET request with shelter_id filter
         response = self.client.get(

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -7,6 +7,7 @@ import re
 from unittest.mock import patch
 from flask import Flask
 from application.rest.service_shifts import service_shift_bp
+from domains.service_shift import ServiceShift
 
 class TestServiceShiftAPI(unittest.TestCase):
     """
@@ -80,7 +81,7 @@ class TestServiceShiftAPI(unittest.TestCase):
                 "shift_name": "Default Shift"
             }
         ]
-        mock_list_use_case.return_value = expected_shifts
+        mock_list_use_case.return_value = [ServiceShift.from_dict(expected_shift)]
 
         # Act: Send GET request.
         response = self.client.get("/service_shift")
@@ -119,19 +120,11 @@ class TestServiceShiftAPI(unittest.TestCase):
             f"/service_shift?shelter_id={test_shelter_id}")
 
         # Parse response data
-        data_str = response.get_data(as_text=True)
-        json_strings = re.findall(r"\{.*?\}", data_str)
-        parsed_objects = [json.loads(s) for s in json_strings]
-        # Assert: Verify the response contains only the filtered shift
+        data = json.loads(response.data.decode("utf-8"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(parsed_objects), 1)
-        self.assertEqual(parsed_objects[0]["shelter_id"], test_shelter_id)
-        # Verify the use case was called with the correct shelter_id
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["shelter_id"], test_shelter_id)
         mock_list_use_case.assert_called_once()
-        # Extract the args that the mock was called with
-        _, kwargs = mock_list_use_case.call_args
-        self.assertEqual(kwargs.get("shelter_id"), test_shelter_id)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -61,7 +61,7 @@ class TestServiceShiftAPI(unittest.TestCase):
         # Arrange: Define the expected list of shift objects.
         expected_shifts = [
             {
-                "_id": 201,
+                "_id": "201",
                 "shelter_id": "1111",
                 "shift_start": 10,
                 "shift_end": 20,
@@ -71,7 +71,7 @@ class TestServiceShiftAPI(unittest.TestCase):
                 "shift_name": "Default Shift"
             },
             {
-                "_id": 202,
+                "_id": "202",
                 "shelter_id": "2222",
                 "shift_start": 10,
                 "shift_end": 20,

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -100,37 +100,37 @@ class TestServiceShiftAPI(unittest.TestCase):
 
     @patch("application.rest.service_shifts.service_shifts_list_use_case")
     def test_get_service_shift_with_shelter_id_filter(self, mock_list_use_case):
-      # Arrange: Define the expected shift for a specific shelter
-      test_shelter_id = "ID1"
-      expected_shift = {
-        "_id": 301,
-        "shelter_id": test_shelter_id,
-        "shift_start": 10,
-        "shift_end": 20,
-        "required_volunteer_count": 1,
-        "max_volunteer_count": 5,
-        "can_sign_up": True,
-        "shift_name": "Default Shift"
-      }
-      mock_list_use_case.return_value = [expected_shift]
+        # Arrange: Define the expected shift for a specific shelter
+        test_shelter_id = "ID1"
+        expected_shift = {
+          "_id": 301,
+          "shelter_id": test_shelter_id,
+          "shift_start": 10,
+          "shift_end": 20,
+          "required_volunteer_count": 1,
+          "max_volunteer_count": 5,
+          "can_sign_up": True,
+          "shift_name": "Default Shift"
+        }
+        mock_list_use_case.return_value = [expected_shift]
 
-       # Act: Send GET request with shelter_id filter
-      response = self.client.get(f"/service_shift?shelter_id={test_shelter_id}")
+        # Act: Send GET request with shelter_id filter
+        response = self.client.get(f"/service_shift?shelter_id={test_shelter_id}")
 
-      # Parse response data
-      data_str = response.get_data(as_text=True)
-      json_strings = re.findall(r"\{.*?\}", data_str)
-      parsed_objects = [json.loads(s) for s in json_strings]
-
-      # Assert: Verify the response contains only the filtered shift
-      self.assertEqual(response.status_code, 200)
-      self.assertEqual(len(parsed_objects), 1)
-      self.assertEqual(parsed_objects[0]["shelter_id"], test_shelter_id)
-      # Verify the use case was called with the correct shelter_id
-      mock_list_use_case.assert_called_once()
-      # Extract the args that the mock was called with
-      _, kwargs = mock_list_use_case.call_args
-      self.assertEqual(kwargs.get("shelter_id"), test_shelter_id)
+        # Parse response data
+        data_str = response.get_data(as_text=True)
+        json_strings = re.findall(r"\{.*?\}", data_str)
+        parsed_objects = [json.loads(s) for s in json_strings]
+  
+        # Assert: Verify the response contains only the filtered shift
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(parsed_objects), 1)
+        self.assertEqual(parsed_objects[0]["shelter_id"], test_shelter_id)
+        # Verify the use case was called with the correct shelter_id
+        mock_list_use_case.assert_called_once()
+        # Extract the args that the mock was called with
+        _, kwargs = mock_list_use_case.call_args
+        self.assertEqual(kwargs.get("shelter_id"), test_shelter_id)
 
 
 if __name__ == "__main__":

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -81,7 +81,7 @@ class TestServiceShiftAPI(unittest.TestCase):
                 "shift_name": "Default Shift"
             }
         ]
-        mock_list_use_case.return_value = [ServiceShift.from_dict(expected_shifts)]
+        mock_list_use_case.return_value = [ServiceShift.from_dict(shift) for shift in expected_shifts]
 
         # Act: Send GET request.
         response = self.client.get("/service_shift")


### PR DESCRIPTION
Fixes #230 

**What was changed?**
Modified server/domains/service_shift.py and server/tests/rest/service_shift/test_service_shift.py. The new test was added to verify that the system can filter and retrieve service shifts using string shelter IDs. It confirms the process of creating a shift with a string ID and then successfully filtering shifts by that string ID in a GET request. This should fail until everything is resolved.