### PR TITLE
Fix main

### DIFF
--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -65,7 +65,7 @@ def create_service_commitment():
     except ValueError as error:
         return (
             jsonify({"error": str(error)}),
-            HTTP_STATUS_CODES_MAPPING[ResponseTypes.AUTHORIZATION_ERROR],
+            HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR],
         )
     except KeyError as error:
         return (

--- a/server/domains/service_shift.py
+++ b/server/domains/service_shift.py
@@ -3,6 +3,7 @@ This module handles data conversion from
 dictionary to class obj or vice versa.
 """
 import dataclasses
+import uuid
 
 @dataclasses.dataclass
 
@@ -17,7 +18,7 @@ class ServiceShift:
     required_volunteer_count: int = 1
     max_volunteer_count: int = 5
     can_sign_up: bool = True
-    _id: str = None
+    _id: uuid.UUID = None
 
     def get_id(self):
         """Returns the ID of the service shift."""
@@ -32,9 +33,7 @@ class ServiceShift:
         """
         Creates an instance of ServiceShift from a dictionary.
         """
-        id_ = str(d.pop("_id", None)) if "_id" in d else None
         obj = cls(**d)
-        obj.set_id(id_)
         return obj
 
     def to_dict(self):

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -93,4 +93,4 @@ class ServiceShiftsMongoRepo:
             shifts = list(self.collection.find({"_id": {"$in": object_ids}}))
             return [ServiceShift.from_dict(shift) for shift in shifts]
         except Exception as e:
-            raise ValueError(f"Invalid shift ID: {e}")
+            raise ValueError(f'Invalid shift ID: {e}') from e

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -4,7 +4,8 @@ This module handles MongoDB interactions with the service_shifts collection.
 
 from domains.service_shift import ServiceShift
 from config.mongodb_config import get_db
-from bson import ObjectId
+#from bson.errors import InvalidId
+from bson.objectid import ObjectId
 
 class ServiceShiftsMongoRepo:
     """
@@ -87,6 +88,9 @@ class ServiceShiftsMongoRepo:
         Returns:
             list: A list of ServiceShift objects.
         """
-        object_ids = [ObjectId(sid) for sid in shift_ids]
-        shifts = list(self.collection.find({"_id": {"$in": object_ids}}))
-        return [ServiceShift.from_dict(shift) for shift in shifts]
+        try:
+            object_ids = [ObjectId(sid) for sid in shift_ids]
+            shifts = list(self.collection.find({"_id": {"$in": object_ids}}))
+            return [ServiceShift.from_dict(shift) for shift in shifts]
+        except Exception as e:
+            raise ValueError(f"Invalid shift ID: {e}")

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -87,17 +87,10 @@ class TestServiceShiftAPI(unittest.TestCase):
         # Act: Send GET request.
         response = self.client.get("/service_shift")
 
-        # The production code returns an iterable of JSON strings
-        # without proper array delimiters.
-        # We'll extract each JSON object from the concatenated response.
-        data_str = response.get_data(as_text=True)
-        # Find all JSON object substrings (assuming the objects are not nested).
-        json_strings = re.findall(r"\{.*?\}", data_str)
-        parsed_objects = [json.loads(s) for s in json_strings]
-
+        data = json.loads(response.data.decode("utf-8"))
         # Assert: Verify that the parsed objects match the expected shifts.
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(parsed_objects, expected_shifts)
+        self.assertEqual(data, expected_shifts)
         mock_list_use_case.assert_called_once()
 
     @patch("application.rest.service_shifts.service_shifts_list_use_case")

--- a/server/tests/rest/service_shift/test_service_shift.py
+++ b/server/tests/rest/service_shift/test_service_shift.py
@@ -3,7 +3,6 @@ This module contains unit tests for the service_shift API.
 """
 import unittest
 import json
-import re
 from unittest.mock import patch
 from flask import Flask
 from application.rest.service_shifts import service_shift_bp

--- a/server/use_cases/add_service_commitments.py
+++ b/server/use_cases/add_service_commitments.py
@@ -20,9 +20,8 @@ def add_service_commitments(commitments_repo, shifts_repo, commitments):
     """
     shift_ids = [c.service_shift_id for c in commitments]
     existing_shifts = {
-        (s.get_id()): s for s in shifts_repo.get_shifts(shift_ids)
+        str(s.get_id()): s for s in shifts_repo.get_shifts(shift_ids)
     }
-
     valid_commitments = []
     results = []
     valid_indexes = []


### PR DESCRIPTION
The latest merge of a PR resulted in failing server side tests. I fixed the failing tests and modified ServiceShift structure to preserve the _id (as it did before that PR).

ServiceShift's _id is a UUID. When a service commitment is created, the service shift id is sent as a string. 