### PR TITLE
Issue 232

### DIFF
--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -52,7 +52,7 @@ function App() {
         <Route path="/upcoming-shifts" element={<UpcomingShifts />} />
         <Route path="/upcoming-requests" element={<UpcomingRequests />} />
         <Route path="/logout" element={<Logout />} />
-        <Route path="/shelter-dashboard" element={<ShelterDashboard />} />
+        <Route path="/shelter-dashboard/:shelterId" element={<ShelterDashboard />} />
         <Route path="/shift-details" element={<ShiftDetails />} />
         <Route path="/request-for-help" element={<RequestForHelp />} />
         <Route path="/set-shifts" element={<Schedule />} />

--- a/client_app/src/components/authentication/Login.js
+++ b/client_app/src/components/authentication/Login.js
@@ -41,10 +41,10 @@ export default function Login({ setAuth, userRole }) {
     e.preventDefault();
     await LoginUser(username, password);
     setAuth(true);
-    navigate(userRole === "shelter" ? "/shelter-dashboard" : "/volunteer-dashboard");
+    navigate(userRole === "shelter" ? "/shelter-dashboard/30207" : "/volunteer-dashboard");
   };  
   if (token) {
-    return <Navigate to={userRole === "shelter" ? "/shelter-dashboard" : "/volunteer-dashboard"} />;
+    return <Navigate to={userRole === "shelter" ? "/shelter-dashboard/30207" : "/volunteer-dashboard"} />;
   }  
 
   return (

--- a/client_app/src/components/shelter/ShelterDashboard.js
+++ b/client_app/src/components/shelter/ShelterDashboard.js
@@ -12,12 +12,11 @@ import { SERVER } from "../../config";
 import AllVolunteers from "./AllVolunteers";
 import AllTodaysShifts from "./AllTodaysShifts";
 
-function ShelterDashboard() {
+function ShelterDashboard({ shelterId }) {
   const [shiftDetails, setShiftDetails] = useState([]);
   const [showAllPastVolunteers, setShowAllPastVolunteers] = useState(false);
   const [showAllTodaysShifts, setShowAllTodaysShifts] = useState(false);
 
-  let shelterId = 30207;
   let startTime = 
       setHours(
         setMinutes(setSeconds(setMilliseconds(new Date(), 0), 0), 0),


### PR DESCRIPTION
Fixes #232

**What was changed?**

Removed the hardcoded shelter id from Shelter Dashboard. Instead, added the ID to the URL. Now, when navigating to a shelter dashboard, we must pass the id: /shelter-dashboard/ID.

**Why was it changed?**

Shelter dashboard provides a way for shelter admin to manage schedule and volunteers for a specific shelter, which is why shelter dashboard needs a way to map to a shelter id. 
