### PR TITLE
Adding confirm button to submit selected shifts to server

### DIFF
--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -53,6 +53,7 @@ function App() {
         <Route path="/shift-details" element={<ShiftDetails />} />
         <Route path="/request-for-help" element={<RequestForHelp />} />
         <Route path="/set-shifts" element={<Schedule />} />
+        <Route path="/set-shifts/:shelterId" element={<Schedule />} />
       </Route>
     </Routes>
   </Router>);

--- a/client_app/src/components/shelter/Schedule.jsx
+++ b/client_app/src/components/shelter/Schedule.jsx
@@ -7,6 +7,7 @@ import "react-big-calendar/lib/css/react-big-calendar.css";
 import { ScheduleData } from "./ScheduleData.js";
 import "../../styles/shelter/Schedule.css";
 import { serviceShiftAPI } from "../../api/serviceShift";
+import { useParams } from "react-router-dom";
 
 const localizer = dayjsLocalizer(dayjs);
 
@@ -20,7 +21,9 @@ function getDefaultWeekRange() {
   return range;
 }
 
-function Schedule({ shelterId }) {
+function Schedule() {
+  const { shelterId } = useParams();
+
   const [scheduledShifts, setScheduledShifts] = useState([]);
   const [activeShiftType, setActiveShiftType] = useState(null);
   const [currentRange, setCurrentRange] = useState(getDefaultWeekRange());
@@ -104,28 +107,19 @@ function Schedule({ shelterId }) {
 
   const handleConfirmShifts = async () => {
     const payload = scheduledShifts.map(shift => ({
-      name: shift.name,
-      start_time: shift.start_time,
-      end_time: shift.end_time,
-      people: shift.people,
+      shift_name: shift.name,
+      shift_start: shift.start_time,
+      shift_end: shift.end_time,
+      required_volunteer_count: shift.people,
       shelter_id: shelterId
     }));
-
-    console.log("shelter id here:", shelterId)
 
     try {
       await serviceShiftAPI.addShifts(payload);
       alert("Shifts successfully created!");
     } catch (error) {
-      console.error("Shift creation error:", error);
-      try {
-        const text = await error?.response?.text();
-        console.error("Server 400 Response Body:", text);
-        alert("Failed to create shifts: " + (text || "Unknown backend error"));
-      } catch (jsonErr) {
-        console.error("Could not read response body:", jsonErr);
-        alert("Failed to create shifts: " + (error?.message || "Unknown error"));
-      }
+      console.log("Error when creating shifts:", error);
+      alert("Issue when creating shifts.");
     }
   };
 

--- a/client_app/src/components/shelter/Schedule.jsx
+++ b/client_app/src/components/shelter/Schedule.jsx
@@ -103,15 +103,15 @@ function Schedule({ shelterId }) {
   const finalEvents = [...userEvents, ...openShiftEvents];
 
   const handleConfirmShifts = async () => {
-    const payload = {
-      shifts: scheduledShifts.map(shift => ({
-        name: shift.name,
-        start_time: new Date(shift.start_time).toISOString(),
-        end_time: new Date(shift.end_time).toISOString(),
-        people: shift.people,
-        shelter_id: shelterId
-      }))
-    };
+    const payload = scheduledShifts.map(shift => ({
+      name: shift.name,
+      start_time: shift.start_time,
+      end_time: shift.end_time,
+      people: shift.people,
+      shelter_id: shelterId
+    }));
+
+    console.log("shelter id here:", shelterId)
 
     try {
       await serviceShiftAPI.addShifts(payload);

--- a/client_app/src/components/shelter/ShiftDetails.js
+++ b/client_app/src/components/shelter/ShiftDetails.js
@@ -19,7 +19,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Select from '@mui/material/Select';
 import Checkbox from '@mui/material/Checkbox';
 import { format } from "date-fns";
-import { serviceShiftAPI } from "../../api/serviceShift"
+// import { serviceShiftAPI } from "../../api/serviceShift"
 
 dayjs.extend(dayjsUTC);
 dayjs.extend(dayjsTimezone);
@@ -68,24 +68,6 @@ export const ShiftDetails = () => {
     })))
     }
 
-    const handleConfirmShifts = async() => {
-      // get selected shift objects from names
-      const confirmedShifts = shiftsList.shifts.filter(shift => {
-        const nameAndTime = shift.name
-        ? `${shift.name}: ${format(shift.startTime, "hh:mm aaaaa'm'")} - ${format(shift.endTime, "hh:mm aaaaa'm'")}`
-        : `${format(shift.startTime, "hh:mm aaaaa'm'")} - ${format(shift.endTime, "hh:mm aaaaa'm'")}`;
-        return selectedShifts.includes(nameAndTime);
-      });
-
-      try {
-        await serviceShiftAPI.addShifts(confirmedShifts);
-        alert("SUCCESS: Shifts sent to the server.");
-      } catch (error) {
-        console.error("Error saving shifts:", error);
-        alert(`Failed to save shifts: ${error.message}`);
-      }
-    };
-
     return (
       <div>
         {isVolunteerModalOpen && <ShiftsModal isVolunteerModalOpen={isVolunteerModalOpen} setIsVolunteerModalOpen={setIsVolunteerModalOpen} />}
@@ -114,21 +96,6 @@ export const ShiftDetails = () => {
                 {renderDropDown()}
               </Select>
             </FormControl>
-            <button
-              onClick={handleConfirmShifts}
-              disabled={selectedShifts.length === 0}
-              style={{
-                marginTop: "10px",
-                padding: "10px 20px",
-                backgroundColor: selectedShifts.length === 0 ? "#ccc" : "#1F75FE",
-                color: "white",
-                border: "none",
-                borderRadius: "5px",
-                cursor: selectedShifts.length === 0 ? "not-allowed" : "pointer"
-              }}
-            >
-              Confirm Selected Shifts
-            </button>
           </div> 
         </div>
         <div className="shiftdetails-table">

--- a/client_app/src/components/shelter/ShiftDetails.js
+++ b/client_app/src/components/shelter/ShiftDetails.js
@@ -19,6 +19,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Select from '@mui/material/Select';
 import Checkbox from '@mui/material/Checkbox';
 import { format } from "date-fns";
+import { serviceShiftAPI } from "../../api/serviceShift"
 
 dayjs.extend(dayjsUTC);
 dayjs.extend(dayjsTimezone);
@@ -67,6 +68,24 @@ export const ShiftDetails = () => {
     })))
     }
 
+    const handleConfirmShifts = async() => {
+      // get selected shift objects from names
+      const confirmedShifts = shiftsList.shifts.filter(shift => {
+        const nameAndTime = shift.name
+        ? `${shift.name}: ${format(shift.startTime, "hh:mm aaaaa'm'")} - ${format(shift.endTime, "hh:mm aaaaa'm'")}`
+        : `${format(shift.startTime, "hh:mm aaaaa'm'")} - ${format(shift.endTime, "hh:mm aaaaa'm'")}`;
+        return selectedShifts.includes(nameAndTime);
+      });
+
+      try {
+        await serviceShiftAPI.addShifts(confirmedShifts);
+        alert("SUCCESS: Shifts sent to the server.");
+      } catch (error) {
+        console.error("Error saving shifts:", error);
+        alert(`Failed to save shifts: ${error.message}`);
+      }
+    };
+
     return (
       <div>
         {isVolunteerModalOpen && <ShiftsModal isVolunteerModalOpen={isVolunteerModalOpen} setIsVolunteerModalOpen={setIsVolunteerModalOpen} />}
@@ -95,6 +114,21 @@ export const ShiftDetails = () => {
                 {renderDropDown()}
               </Select>
             </FormControl>
+            <button
+              onClick={handleConfirmShifts}
+              disabled={selectedShifts.length === 0}
+              style={{
+                marginTop: "10px",
+                padding: "10px 20px",
+                backgroundColor: selectedShifts.length === 0 ? "#ccc" : "#1F75FE",
+                color: "white",
+                border: "none",
+                borderRadius: "5px",
+                cursor: selectedShifts.length === 0 ? "not-allowed" : "pointer"
+              }}
+            >
+              Confirm Selected Shifts
+            </button>
           </div> 
         </div>
         <div className="shiftdetails-table">


### PR DESCRIPTION
Fixes #226 

**What was changed?**

* Modified the `ShiftDetails.js` component in the `components/shelter` directory.
* Added a new "Confirm Selected Shifts" button that allows shelter admins to submit shifts to the server.
* Implemented logic to collect selected shifts from the dropdown and send them via the `serviceShiftAPI.addShifts()` function.

**Why was it changed?**

Before, when a shelter admin selected predefined shifts for a day, those shifts were displayed on the calendar but never actually sent to the server. This change provides a way for admins to confirm their shift selection, triggering a POST request to the backend to store them.

**How was it changed?**

* Imported `serviceShiftAPI` from the `api/serviceShift.js` file.
* In `ShiftDetails.js`, added a `handleConfirmShifts` function that filters selected shifts from the dropdown, sends them to the server using `serviceShiftAPI.addShifts()`, and alerts the user of success or failure.
* Added a button below the shift selector that calls this function on click.
* Disabled the button when no shifts are selected to prevent accidental submissions.

**Screenshots:**
*BEFORE:*
<img width="1235" alt="Screenshot 2025-04-06 at 5 19 18 PM" src="https://github.com/user-attachments/assets/c4b6f02c-8e40-495d-add9-5de7311bf6dc" />
*AFTER (when button is enabled):*
<img width="1287" alt="Screenshot 2025-04-06 at 5 21 00 PM" src="https://github.com/user-attachments/assets/69593b9c-5d67-4206-9387-1e6890f0daf7" />
*(when button is disabled):*
<img width="1287" alt="Screenshot 2025-04-06 at 5 21 33 PM" src="https://github.com/user-attachments/assets/dcc5fd31-c4e3-45ec-baab-01e12b8eca60" />
