### PR TITLE
GET /user_permission API endpoint gives system admin explicit access to all shelters

### DIFF
--- a/server/application/rest/authorization/authorization.py
+++ b/server/application/rest/authorization/authorization.py
@@ -10,12 +10,14 @@ from use_cases.authorization.is_authorized import is_authorized
 from authentication.authenticate_user import get_user_from_token
 from application.rest.status_codes import HTTP_STATUS_CODES_MAPPING
 from repository.mongo.authorization import PermissionsMongoRepo
+from repository.mongo.shelter import ShelterRepo
 from serializers.user_permission import UserPermissionJsonEncoder
 from domains.resources import Resources
 from responses import ResponseTypes
 
 authorization_blueprint = Blueprint('authorization', __name__)
 repo = PermissionsMongoRepo()
+shelter_repo = ShelterRepo()
 
 @authorization_blueprint.route('/user_permission', methods=['GET', 'POST'])
 def permission():
@@ -53,7 +55,7 @@ def permission():
         )
     user_id = user[0]
     if request.method == 'GET':
-        user_permission = get_user_permission(repo, user_id)
+        user_permission = get_user_permission(repo, user_id, shelter_repo)
         return Response(
             json.dumps(user_permission, cls=UserPermissionJsonEncoder),
             mimetype='application/json',

--- a/server/domains/authorization/user_permission.py
+++ b/server/domains/authorization/user_permission.py
@@ -3,6 +3,7 @@ UserPermission class definition.
 """
 import uuid
 import dataclasses
+from domains.resources import Resources
 from typing import List
 
 from domains.authorization.access import Access
@@ -73,3 +74,11 @@ class UserPermission:
         self.full_access.append(
             Access(resource_type=resource_type, resource_ids=[resource_id])
         )
+    def is_system_admin(self):
+        """
+        Check if the user has system admin access.
+        """
+        for access in self.full_access:
+            if access.resource_type == Resources.SYSTEM:
+                return True
+        return False

--- a/server/use_cases/authorization/get_user_permission.py
+++ b/server/use_cases/authorization/get_user_permission.py
@@ -2,10 +2,15 @@
 This file contains the use case to get the user permission 
 of a user in a repository.
 """
-
-def get_user_permission(repo, user_email):
+from domains.resources import Resources
+def get_user_permission(permissions_repo, user_email, shelter_repo = None):
     """
     Retrieve the user permission of a user in a repository.
     """
-    user_permission = repo.get_user_permissions(user_email)
+    user_permission = permissions_repo.get_user_permissions(user_email)
+    if shelter_repo is not None and user_permission.is_system_admin():
+        # Get all shelters if the user is a system admin
+        shelters = shelter_repo.list()
+        for shelter in shelters:
+            user_permission.add_access(Resources.SHELTER, str(shelter.get_id()))
     return user_permission


### PR DESCRIPTION
Fixes #i260

**What was changed?**

I updated the GET /user_permission API endpoint for a system admin. When a system admin requests permissions, we return all explicitly defined permissions (from the database) and the implied permission to access all shelters. 

**Why was it changed?**
Previously, the GET /user_permission API endpoint would only return permissions explicitly defined in our database. For example, a system admin's permissions would be returned as:
```
{
    "full_access": [
        {
            "resource_type": "system",
            "resource_ids": [
                null
            ]
        }
```

Now, when we request system admin permissions, we get the explicit permissions from the database and the implied permissions to manage all shelters. For example:
```
{
    "full_access": [
        {
            "resource_type": "system",
            "resource_ids": [
                null
            ]
        },
        {
            "resource_type": "shelter",
            "resource_ids": [
                "6806746a227bca1c924f62eb",
                "680674b8227bca1c924f62ef"
            ]
        }
    ]
}
```
**How was it changed?**
Updated the get_user_permission use case: added an optional parameter - the shelter repo. If a system admin's permissions are being processed and shelter_repo is passed, we retrieve all shelters from that repo and include a list of all shelter ids in the resource_ids field.
