### PR TITLE
Fixing Issue 252

### DIFF
--- a/server/application/rest/schedule.py
+++ b/server/application/rest/schedule.py
@@ -1,0 +1,39 @@
+"""
+module for handling the schedule endpoint
+"""
+from flask import request, jsonify
+from application.rest import app
+from repository.mongo.service_shifts import ServiceShiftsMongoRepo
+
+#new instance of the repo with the schedule collection
+schedule_repo = ServiceShiftsMongoRepo(collection_name='schedule')
+
+@app.route('/schedule', methods=['POST'])
+def create_schedule():
+    """
+    endpoint to create repeatable schedule templates.
+    wants a JSON array of service shift objects.
+    """
+    try:
+        #parsing the request body as JSON
+        shifts = request.get_json()
+        if not shifts or not isinstance(shifts, list):
+            return jsonify({'error': 'Expected a list of service shifts'}), 400
+        #going to process every shift
+        inserted_ids = []
+        for shift in shifts:
+            #making sure the shift has required fields
+            if 'timestamp' not in shift or 'service' not in shift:
+                return jsonify({'error'
+                                : 'Shift requires timestamp + service fields'}),
+                400
+            #timestamp here is "milliseconds since midnight" instead of epoch
+            # check this, trying to insert shift into  schedule collection
+            result = schedule_repo.insert(shift)
+            inserted_ids.append(str(result))
+        #return success with the IDs of created schedules
+        return jsonify({'message': 'Schedule created successfully',
+                        'ids': inserted_ids}), 201
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+    

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -12,6 +12,8 @@ from domains.service_shift import ServiceShift
 from application.rest.status_codes import HTTP_STATUS_CODES_MAPPING
 from responses import ResponseTypes
 from serializers.service_shift import ServiceShiftJsonEncoder
+from use_cases.get_schedule_shifts_use_case import get_schedule_shifts_use_case
+from repository.mongo.schedule_repo import ScheduleMongoRepo
 
 service_shift_bp = Blueprint("service_shift", __name__)
 
@@ -87,3 +89,23 @@ def handle_service_shift():
             mimetype="application/json",
             status=status_code,
         )
+
+@service_shift_bp.route("/schedule", methods=["GET"])
+@cross_origin()
+def handle_schedule_shift():
+    shelter_id = request.args.get("shelter_id")
+    if not shelter_id:
+        return Response(
+            json.dumps({"error": "shelter_id is required"}),
+            mimetype="application/json",
+            status=400
+        )
+        
+    repo = ScheduleMongoRepo()
+    shifts = get_schedule_shifts_use_case(repo, shelter_id)
+
+    return Response(
+        json.dumps(shifts, cls=ServiceShiftJsonEncoder),
+        mimetype="application/json",
+        status=200
+    )

--- a/server/repository/mongo/schedule_repo.py
+++ b/server/repository/mongo/schedule_repo.py
@@ -1,0 +1,11 @@
+from domains.service_shift import ServiceShift
+from config.mongodb_config import get_db
+
+class ScheduleMongoRepo:
+    def __init__(self):
+        self.db = get_db()
+        self.collection = self.db.schedules
+
+    def list_by_shelter_id(self, shelter_id):
+        shifts = self.collection.find({"shelter_id": shelter_id})
+        return [ServiceShift.from_dict(s) for s in shifts]

--- a/server/use_cases/get_schedule_shifts_use_case.py
+++ b/server/use_cases/get_schedule_shifts_use_case.py
@@ -1,0 +1,2 @@
+def get_schedule_shifts_use_case(repo, shelter_id):
+    return repo.list_by_shelter_id(shelter_id)


### PR DESCRIPTION
Fixes #252

**What was changed?**

* Added a new API endpoint `/schedule` to allow shelter admins to retrieve pre-loaded shift schedules.
* Created a new repository `ScheduleMongoRepo` to interact with the `schedules` collection in the database.
* Added a new use case `get_schedule_shifts_use_case.py` to handle the retrieval of schedule shifts based on shelter ID.
* Modified `server/application/rest/service_shifts.py` to register the new `/schedule` route.

**Why was it changed?**

Previously, shelter admins could not load their pre-defined schedule shifts when opening shelters. This change adds the necessary backend support to fetch pre-saved schedules associated with a given shelter ID.

**How was it changed?**

* New file: `server/use_cases/get_schedule_shifts_use_case.py`, added a function retrieve shifts by shelter ID.
* New file: `server/repository/mongo/schedule_repo.py`, created a new MongoDB repository class to point to the `schedules` collection.
* Modified file: `server/application/rest/service_shifts.py`, imported the new repository and use case. Added a new route `/schedule` that accepts a GET request with a `shelter_id` parameter.
