### PR TITLE
Issue 253 repeatable shifts

### DIFF
--- a/client_app/package-lock.json
+++ b/client_app/package-lock.json
@@ -23,6 +23,7 @@
         "chart.js": "^4.4.0",
         "date-fns": "^2.30.0",
         "dayjs": "^1.11.13",
+        "jest-fetch-mock": "^3.0.3",
         "react": "^18.2.0",
         "react-big-calendar": "^1.15.0",
         "react-bootstrap": "^2.9.1",
@@ -8320,6 +8321,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -13870,6 +13880,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
@@ -17150,6 +17170,48 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -19056,6 +19118,12 @@
       "dependencies": {
         "asap": "~2.0.6"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",

--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -46,13 +46,13 @@ function App() {
           <Route path="shift-details" element={<ShiftDetails />} />
           <Route path="request-for-help" element={<RequestForHelp />} />
           <Route path="upcoming-requests" element={<UpcomingRequests />} />
+          <Route path="repeatable-shifts" element={<RepeatableShifts />} />
         </Route>
         <Route path="/volunteer-dashboard" element={<VolunteerDashboardLayout />}>
           <Route index element={<VolunteerDashboard />} />
           <Route path="shelters" element={<Shelters />} />
           <Route path="past-shifts" element={<PastShifts />} />
           <Route path="upcoming-shifts" element={<UpcomingShifts />} />
-          <Route path="repeatable-shifts" element={<RepeatableShifts />} />
         </Route>
         <Route path="/logout" element={<Logout setAuth={setAuth} />} />
       </Route>

--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -22,6 +22,7 @@ import { ShiftDetails } from "./components/shelter/ShiftDetails";
 import UpcomingRequests from "./components/shelter/UpcomingRequests";
 import Settings from "./components/shelter/Settings";
 import Schedule from "./components/shelter/Schedule"; 
+import RepeatableShifts from "./components/shelter/RepeatableShifts";
 
 // Admin dashboard components
 import AdminDashboard from "./components/admin/AdminDashboard";
@@ -51,6 +52,7 @@ function App() {
           <Route path="shelters" element={<Shelters />} />
           <Route path="past-shifts" element={<PastShifts />} />
           <Route path="upcoming-shifts" element={<UpcomingShifts />} />
+          <Route path="repeatable-shifts" element={<RepeatableShifts />} />
         </Route>
         <Route path="/logout" element={<Logout setAuth={setAuth} />} />
       </Route>

--- a/client_app/src/components/shelter/RepeatableShifts.js
+++ b/client_app/src/components/shelter/RepeatableShifts.js
@@ -4,13 +4,15 @@ import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 
 const RepeatableShifts = () => {
-  const { shelterId } = useParams(); // grab the shelterId from URL
+  const { shelterId } = useParams();
 
   const [shifts, setShifts] = useState([]);
   const [newShift, setNewShift] = useState({
-    day: "",
-    startTime: "",
-    endTime: ""
+    shift_name: "",
+    shift_start: "",
+    shift_end: "",
+    required_volunteer_count: 1,
+    max_volunteer_count: 5
   });
 
   const handleInputChange = (e) => {
@@ -18,17 +20,41 @@ const RepeatableShifts = () => {
     setNewShift({ ...newShift, [name]: value });
   };
 
+  const timeToMilliseconds = (timeStr) => {
+    const [hours, minutes] = timeStr.split(":").map(Number);
+    return (hours * 60 + minutes) * 60 * 1000;
+  };
+
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (newShift.day && newShift.startTime && newShift.endTime) {
-      setShifts([...shifts, newShift]);
-      setNewShift({ day: "", startTime: "", endTime: "" });
+    if (newShift.shift_start && newShift.shift_end) {
+      const formattedShift = {
+        shift_name: newShift.shift_name,
+        shift_start: timeToMilliseconds(newShift.shift_start),
+        shift_end: timeToMilliseconds(newShift.shift_end),
+        required_volunteer_count: Number(newShift.required_volunteer_count) || 1,
+        max_volunteer_count: Number(newShift.max_volunteer_count) || 5
+      };
+      setShifts([...shifts, formattedShift]);
+      setNewShift({
+        shift_name: "",
+        shift_start: "",
+        shift_end: "",
+        required_volunteer_count: 1,
+        max_volunteer_count: 5
+      });
     }
   };
 
   const updateShift = (index, field, value) => {
     const updatedShifts = [...shifts];
-    updatedShifts[index][field] = value;
+    if (field === "shift_start" || field === "shift_end") {
+      updatedShifts[index][field] = timeToMilliseconds(value);
+    } else if (field === "required_volunteer_count" || field === "max_volunteer_count") {
+      updatedShifts[index][field] = Number(value);
+    } else {
+      updatedShifts[index][field] = value;
+    }
     setShifts(updatedShifts);
   };
 
@@ -37,19 +63,27 @@ const RepeatableShifts = () => {
     setShifts(updatedShifts);
   };
 
+  const millisecondsToTime = (ms) => {
+    const totalMinutes = ms / (60 * 1000);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = Math.floor(totalMinutes % 60);
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+  };
+
   return (
-    <div className="repeatable-shifts-page">
+    <div className="repeatable-shifts-page" style={{ padding: "20px" }}>
       <h2>Define Repeatable Shifts for Shelter {shelterId}</h2>
-      {/* Add new shift form */}
-      <form onSubmit={handleSubmit}>
+      {/* Add New Shift Form */}
+      <form onSubmit={handleSubmit} style={{ marginBottom: "30px" }}>
         <label>
-          Day:
+          Shift Name (optional):
           <input
             type="text"
-            name="day"
-            value={newShift.day}
+            name="shift_name"
+            value={newShift.shift_name}
             onChange={handleInputChange}
-            placeholder="e.g., Monday"
+            placeholder="e.g., Morning Shift"
+            style={{ marginLeft: "10px", marginBottom: "10px" }}
           />
         </label>
         <br />
@@ -57,9 +91,10 @@ const RepeatableShifts = () => {
           Start Time:
           <input
             type="time"
-            name="startTime"
-            value={newShift.startTime}
+            name="shift_start"
+            value={newShift.shift_start}
             onChange={handleInputChange}
+            style={{ marginLeft: "10px", marginBottom: "10px" }}
           />
         </label>
         <br />
@@ -67,42 +102,101 @@ const RepeatableShifts = () => {
           End Time:
           <input
             type="time"
-            name="endTime"
-            value={newShift.endTime}
+            name="shift_end"
+            value={newShift.shift_end}
             onChange={handleInputChange}
+            style={{ marginLeft: "10px", marginBottom: "10px" }}
+          />
+        </label>
+        <br />
+        <label>
+          Required Volunteers:
+          <input
+            type="number"
+            name="required_volunteer_count"
+            value={newShift.required_volunteer_count}
+            onChange={handleInputChange}
+            min="1"
+            style={{ marginLeft: "10px", marginBottom: "10px" }}
+          />
+        </label>
+        <br />
+        <label>
+          Max Volunteers:
+          <input
+            type="number"
+            name="max_volunteer_count"
+            value={newShift.max_volunteer_count}
+            onChange={handleInputChange}
+            min="1"
+            style={{ marginLeft: "10px", marginBottom: "10px" }}
           />
         </label>
         <br />
         <button type="submit">Add Shift</button>
       </form>
-      {/* List of shifts */}
-      <div style={{ marginTop: "30px" }}>
-        <h3>Current Repeatable Shifts</h3>
-        {shifts.length === 0 ? (
-          <p>No shifts added yet.</p>
-        ) : (
-          shifts.map((shift, index) => (
-            <div key={index} style={{ marginBottom: "15px" }}>
-              <input
-                type="text"
-                value={shift.day}
-                onChange={(e) => updateShift(index, "day", e.target.value)}
-              />
-              <input
-                type="time"
-                value={shift.startTime}
-                onChange={(e) => updateShift(index, "startTime", e.target.value)}
-              />
-              <input
-                type="time"
-                value={shift.endTime}
-                onChange={(e) => updateShift(index, "endTime", e.target.value)}
-              />
-              <button onClick={() => deleteShift(index)}>Delete</button>
-            </div>
-          ))
-        )}
-      </div>
+      {/* Current Repeatable Shifts */}
+      <h3>Current Repeatable Shifts</h3>
+      {shifts.length === 0 ? (
+        <p>No shifts added yet.</p>
+      ) : (
+        <table border="1" cellPadding="8" style={{ borderCollapse: "collapse", width: "100%" }}>
+          <thead>
+            <tr>
+              <th>Shift Name</th>
+              <th>Start Time</th>
+              <th>End Time</th>
+              <th>Required Volunteers</th>
+              <th>Max Volunteers</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {shifts.map((shift, index) => (
+              <tr key={index}>
+                <td>
+                  <input
+                    type="text"
+                    value={shift.shift_name}
+                    onChange={(e) => updateShift(index, "shift_name", e.target.value)}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="time"
+                    onChange={(e) => updateShift(index, "shift_start", e.target.value)}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="time"
+                    onChange={(e) => updateShift(index, "shift_end", e.target.value)}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    value={shift.required_volunteer_count}
+                    onChange={(e) => updateShift(index, "required_volunteer_count", e.target.value)}
+                    min="1"
+                  />
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    value={shift.max_volunteer_count}
+                    onChange={(e) => updateShift(index, "max_volunteer_count", e.target.value)}
+                    min="1"
+                  />
+                </td>
+                <td>
+                  <button onClick={() => deleteShift(index)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 };

--- a/client_app/src/components/shelter/RepeatableShifts.js
+++ b/client_app/src/components/shelter/RepeatableShifts.js
@@ -1,39 +1,108 @@
 // client_app/src/components/shelter/RepeatableShifts.js
 
 import React, { useState } from "react";
+import { useParams } from "react-router-dom";
 
 const RepeatableShifts = () => {
-  const [day, setDay] = useState("");
-  const [startTime, setStartTime] = useState("");
-  const [endTime, setEndTime] = useState("");
+  const { shelterId } = useParams(); // grab the shelterId from URL
+
+  const [shifts, setShifts] = useState([]);
+  const [newShift, setNewShift] = useState({
+    day: "",
+    startTime: "",
+    endTime: ""
+  });
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setNewShift({ ...newShift, [name]: value });
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    // TODO: call an API here to send the new repeatable shift
-    console.log("Submitted shift:", { day, startTime, endTime });
+    if (newShift.day && newShift.startTime && newShift.endTime) {
+      setShifts([...shifts, newShift]);
+      setNewShift({ day: "", startTime: "", endTime: "" });
+    }
+  };
+
+  const updateShift = (index, field, value) => {
+    const updatedShifts = [...shifts];
+    updatedShifts[index][field] = value;
+    setShifts(updatedShifts);
+  };
+
+  const deleteShift = (index) => {
+    const updatedShifts = shifts.filter((_, i) => i !== index);
+    setShifts(updatedShifts);
   };
 
   return (
     <div className="repeatable-shifts-page">
-      <h2>Define Repeatable Shift</h2>
+      <h2>Define Repeatable Shifts for Shelter {shelterId}</h2>
+      {/* Add new shift form */}
       <form onSubmit={handleSubmit}>
         <label>
           Day:
-          <input type="text" value={day} onChange={(e) => setDay(e.target.value)} placeholder="e.g., Monday" />
+          <input
+            type="text"
+            name="day"
+            value={newShift.day}
+            onChange={handleInputChange}
+            placeholder="e.g., Monday"
+          />
         </label>
         <br />
         <label>
           Start Time:
-          <input type="time" value={startTime} onChange={(e) => setStartTime(e.target.value)} />
+          <input
+            type="time"
+            name="startTime"
+            value={newShift.startTime}
+            onChange={handleInputChange}
+          />
         </label>
         <br />
         <label>
           End Time:
-          <input type="time" value={endTime} onChange={(e) => setEndTime(e.target.value)} />
+          <input
+            type="time"
+            name="endTime"
+            value={newShift.endTime}
+            onChange={handleInputChange}
+          />
         </label>
         <br />
-        <button type="submit">Save Shift</button>
+        <button type="submit">Add Shift</button>
       </form>
+      {/* List of shifts */}
+      <div style={{ marginTop: "30px" }}>
+        <h3>Current Repeatable Shifts</h3>
+        {shifts.length === 0 ? (
+          <p>No shifts added yet.</p>
+        ) : (
+          shifts.map((shift, index) => (
+            <div key={index} style={{ marginBottom: "15px" }}>
+              <input
+                type="text"
+                value={shift.day}
+                onChange={(e) => updateShift(index, "day", e.target.value)}
+              />
+              <input
+                type="time"
+                value={shift.startTime}
+                onChange={(e) => updateShift(index, "startTime", e.target.value)}
+              />
+              <input
+                type="time"
+                value={shift.endTime}
+                onChange={(e) => updateShift(index, "endTime", e.target.value)}
+              />
+              <button onClick={() => deleteShift(index)}>Delete</button>
+            </div>
+          ))
+        )}
+      </div>
     </div>
   );
 };

--- a/client_app/src/components/shelter/RepeatableShifts.js
+++ b/client_app/src/components/shelter/RepeatableShifts.js
@@ -1,0 +1,41 @@
+// client_app/src/components/shelter/RepeatableShifts.js
+
+import React, { useState } from "react";
+
+const RepeatableShifts = () => {
+  const [day, setDay] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // TODO: call an API here to send the new repeatable shift
+    console.log("Submitted shift:", { day, startTime, endTime });
+  };
+
+  return (
+    <div className="repeatable-shifts-page">
+      <h2>Define Repeatable Shift</h2>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Day:
+          <input type="text" value={day} onChange={(e) => setDay(e.target.value)} placeholder="e.g., Monday" />
+        </label>
+        <br />
+        <label>
+          Start Time:
+          <input type="time" value={startTime} onChange={(e) => setStartTime(e.target.value)} />
+        </label>
+        <br />
+        <label>
+          End Time:
+          <input type="time" value={endTime} onChange={(e) => setEndTime(e.target.value)} />
+        </label>
+        <br />
+        <button type="submit">Save Shift</button>
+      </form>
+    </div>
+  );
+};
+
+export default RepeatableShifts;

--- a/client_app/src/components/shelter/RepeatableShifts.js
+++ b/client_app/src/components/shelter/RepeatableShifts.js
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
+import "../../styles/shelter/RepeatableShifts.css";
 
 const RepeatableShifts = () => {
   const { shelterId } = useParams(); // grab the shelterId from URL
@@ -62,7 +63,6 @@ const RepeatableShifts = () => {
   return (
     <div className="repeatable-shifts-page" style={{ maxWidth: "900px", margin: "0 auto", padding: "20px" }}>
       <h2>Define Repeatable Shifts for Shelter {shelterId}</h2>
-
       <form onSubmit={handleSubmit} style={{ marginBottom: "20px" }}>
         <label>
           Shift Name (optional):
@@ -122,7 +122,6 @@ const RepeatableShifts = () => {
         </button>
         {successMessage && <p style={{ color: "green", marginTop: "10px" }}>{successMessage}</p>}
       </form>
-
       {/* List of shifts */}
       <div>
         <h3>Current Repeatable Shifts</h3>

--- a/client_app/src/components/shelter/RepeatableShifts.js
+++ b/client_app/src/components/shelter/RepeatableShifts.js
@@ -4,57 +4,53 @@ import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 
 const RepeatableShifts = () => {
-  const { shelterId } = useParams();
+  const { shelterId } = useParams(); // grab the shelterId from URL
 
   const [shifts, setShifts] = useState([]);
   const [newShift, setNewShift] = useState({
-    shift_name: "",
-    shift_start: "",
-    shift_end: "",
-    required_volunteer_count: 1,
-    max_volunteer_count: 5
+    shiftName: "",
+    startTime: "",
+    endTime: "",
+    requiredVolunteers: 1,
+    maxVolunteers: 5,
   });
+  const [successMessage, setSuccessMessage] = useState("");
+
+  // Convert HH:MM to milliseconds since midnight
+  const timeStringToMillis = (timeStr) => {
+    const [hours, minutes] = timeStr.split(":").map(Number);
+    return (hours * 60 + minutes) * 60 * 1000;
+  };
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
     setNewShift({ ...newShift, [name]: value });
   };
 
-  const timeToMilliseconds = (timeStr) => {
-    const [hours, minutes] = timeStr.split(":").map(Number);
-    return (hours * 60 + minutes) * 60 * 1000;
-  };
-
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (newShift.shift_start && newShift.shift_end) {
-      const formattedShift = {
-        shift_name: newShift.shift_name,
-        shift_start: timeToMilliseconds(newShift.shift_start),
-        shift_end: timeToMilliseconds(newShift.shift_end),
-        required_volunteer_count: Number(newShift.required_volunteer_count) || 1,
-        max_volunteer_count: Number(newShift.max_volunteer_count) || 5
+    if (newShift.startTime && newShift.endTime) {
+      const newEntry = {
+        ...newShift,
+        shift_start: timeStringToMillis(newShift.startTime),
+        shift_end: timeStringToMillis(newShift.endTime),
       };
-      setShifts([...shifts, formattedShift]);
+      setShifts([...shifts, newEntry]);
       setNewShift({
-        shift_name: "",
-        shift_start: "",
-        shift_end: "",
-        required_volunteer_count: 1,
-        max_volunteer_count: 5
+        shiftName: "",
+        startTime: "",
+        endTime: "",
+        requiredVolunteers: 1,
+        maxVolunteers: 5,
       });
+      setSuccessMessage("Shift added successfully!");
+      setTimeout(() => setSuccessMessage(""), 3000); // Remove after 3 sec
     }
   };
 
   const updateShift = (index, field, value) => {
     const updatedShifts = [...shifts];
-    if (field === "shift_start" || field === "shift_end") {
-      updatedShifts[index][field] = timeToMilliseconds(value);
-    } else if (field === "required_volunteer_count" || field === "max_volunteer_count") {
-      updatedShifts[index][field] = Number(value);
-    } else {
-      updatedShifts[index][field] = value;
-    }
+    updatedShifts[index][field] = value;
     setShifts(updatedShifts);
   };
 
@@ -63,27 +59,19 @@ const RepeatableShifts = () => {
     setShifts(updatedShifts);
   };
 
-  const millisecondsToTime = (ms) => {
-    const totalMinutes = ms / (60 * 1000);
-    const hours = Math.floor(totalMinutes / 60);
-    const minutes = Math.floor(totalMinutes % 60);
-    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
-  };
-
   return (
-    <div className="repeatable-shifts-page" style={{ padding: "20px" }}>
+    <div className="repeatable-shifts-page" style={{ maxWidth: "900px", margin: "0 auto", padding: "20px" }}>
       <h2>Define Repeatable Shifts for Shelter {shelterId}</h2>
-      {/* Add New Shift Form */}
-      <form onSubmit={handleSubmit} style={{ marginBottom: "30px" }}>
+
+      <form onSubmit={handleSubmit} style={{ marginBottom: "20px" }}>
         <label>
           Shift Name (optional):
           <input
             type="text"
-            name="shift_name"
-            value={newShift.shift_name}
+            name="shiftName"
+            value={newShift.shiftName}
             onChange={handleInputChange}
             placeholder="e.g., Morning Shift"
-            style={{ marginLeft: "10px", marginBottom: "10px" }}
           />
         </label>
         <br />
@@ -91,10 +79,9 @@ const RepeatableShifts = () => {
           Start Time:
           <input
             type="time"
-            name="shift_start"
-            value={newShift.shift_start}
+            name="startTime"
+            value={newShift.startTime}
             onChange={handleInputChange}
-            style={{ marginLeft: "10px", marginBottom: "10px" }}
           />
         </label>
         <br />
@@ -102,10 +89,9 @@ const RepeatableShifts = () => {
           End Time:
           <input
             type="time"
-            name="shift_end"
-            value={newShift.shift_end}
+            name="endTime"
+            value={newShift.endTime}
             onChange={handleInputChange}
-            style={{ marginLeft: "10px", marginBottom: "10px" }}
           />
         </label>
         <br />
@@ -113,11 +99,10 @@ const RepeatableShifts = () => {
           Required Volunteers:
           <input
             type="number"
-            name="required_volunteer_count"
-            value={newShift.required_volunteer_count}
+            name="requiredVolunteers"
+            value={newShift.requiredVolunteers}
             onChange={handleInputChange}
             min="1"
-            style={{ marginLeft: "10px", marginBottom: "10px" }}
           />
         </label>
         <br />
@@ -125,78 +110,85 @@ const RepeatableShifts = () => {
           Max Volunteers:
           <input
             type="number"
-            name="max_volunteer_count"
-            value={newShift.max_volunteer_count}
+            name="maxVolunteers"
+            value={newShift.maxVolunteers}
             onChange={handleInputChange}
             min="1"
-            style={{ marginLeft: "10px", marginBottom: "10px" }}
           />
         </label>
         <br />
-        <button type="submit">Add Shift</button>
+        <button type="submit" style={{ marginTop: "10px" }}>
+          Add Shift
+        </button>
+        {successMessage && <p style={{ color: "green", marginTop: "10px" }}>{successMessage}</p>}
       </form>
-      {/* Current Repeatable Shifts */}
-      <h3>Current Repeatable Shifts</h3>
-      {shifts.length === 0 ? (
-        <p>No shifts added yet.</p>
-      ) : (
-        <table border="1" cellPadding="8" style={{ borderCollapse: "collapse", width: "100%" }}>
-          <thead>
-            <tr>
-              <th>Shift Name</th>
-              <th>Start Time</th>
-              <th>End Time</th>
-              <th>Required Volunteers</th>
-              <th>Max Volunteers</th>
-              <th>Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            {shifts.map((shift, index) => (
-              <tr key={index}>
-                <td>
-                  <input
-                    type="text"
-                    value={shift.shift_name}
-                    onChange={(e) => updateShift(index, "shift_name", e.target.value)}
-                  />
-                </td>
-                <td>
-                  <input
-                    type="time"
-                    onChange={(e) => updateShift(index, "shift_start", e.target.value)}
-                  />
-                </td>
-                <td>
-                  <input
-                    type="time"
-                    onChange={(e) => updateShift(index, "shift_end", e.target.value)}
-                  />
-                </td>
-                <td>
-                  <input
-                    type="number"
-                    value={shift.required_volunteer_count}
-                    onChange={(e) => updateShift(index, "required_volunteer_count", e.target.value)}
-                    min="1"
-                  />
-                </td>
-                <td>
-                  <input
-                    type="number"
-                    value={shift.max_volunteer_count}
-                    onChange={(e) => updateShift(index, "max_volunteer_count", e.target.value)}
-                    min="1"
-                  />
-                </td>
-                <td>
-                  <button onClick={() => deleteShift(index)}>Delete</button>
-                </td>
+
+      {/* List of shifts */}
+      <div>
+        <h3>Current Repeatable Shifts</h3>
+        {shifts.length === 0 ? (
+          <p>No shifts added yet.</p>
+        ) : (
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                <th>Shift Name</th>
+                <th>Start Time</th>
+                <th>End Time</th>
+                <th>Required Volunteers</th>
+                <th>Max Volunteers</th>
+                <th>Action</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+            </thead>
+            <tbody>
+              {shifts.map((shift, index) => (
+                <tr key={index}>
+                  <td>
+                    <input
+                      type="text"
+                      value={shift.shiftName}
+                      onChange={(e) => updateShift(index, "shiftName", e.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="time"
+                      value={shift.startTime}
+                      onChange={(e) => updateShift(index, "startTime", e.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="time"
+                      value={shift.endTime}
+                      onChange={(e) => updateShift(index, "endTime", e.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="number"
+                      min="1"
+                      value={shift.requiredVolunteers}
+                      onChange={(e) => updateShift(index, "requiredVolunteers", e.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="number"
+                      min="1"
+                      value={shift.maxVolunteers}
+                      onChange={(e) => updateShift(index, "maxVolunteers", e.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <button onClick={() => deleteShift(index)}>Delete</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
     </div>
   );
 };

--- a/client_app/src/components/shelter/RepeatableShifts.js
+++ b/client_app/src/components/shelter/RepeatableShifts.js
@@ -17,7 +17,6 @@ const RepeatableShifts = () => {
   });
   const [successMessage, setSuccessMessage] = useState("");
 
-  // Convert HH:MM to milliseconds since midnight
   const timeStringToMillis = (timeStr) => {
     const [hours, minutes] = timeStr.split(":").map(Number);
     return (hours * 60 + minutes) * 60 * 1000;
@@ -44,8 +43,17 @@ const RepeatableShifts = () => {
         requiredVolunteers: 1,
         maxVolunteers: 5,
       });
-      setSuccessMessage("Shift added successfully!");
-      setTimeout(() => setSuccessMessage(""), 3000); // Remove after 3 sec
+    }
+  };
+
+  const handleSubmitAllShifts = async () => {
+    try {
+      // Replace with actual API call when ready
+      console.log("Submitting shifts to backend:", shifts);
+      setSuccessMessage("Schedule submitted successfully!");
+      setTimeout(() => setSuccessMessage(""), 3000);
+    } catch (error) {
+      console.error("Error submitting schedule:", error);
     }
   };
 
@@ -61,9 +69,12 @@ const RepeatableShifts = () => {
   };
 
   return (
-    <div className="repeatable-shifts-page" style={{ maxWidth: "900px", margin: "0 auto", padding: "20px" }}>
+    <div className="repeatable-shifts-page">
       <h2>Define Repeatable Shifts for Shelter {shelterId}</h2>
-      <form onSubmit={handleSubmit} style={{ marginBottom: "20px" }}>
+      <p className="instructions">
+        Define the repeatable shifts below. Once you've added all your shifts, click "Submit Schedule" to save them.
+      </p>
+      <form onSubmit={handleSubmit} className="shift-form">
         <label>
           Shift Name (optional):
           <input
@@ -74,7 +85,6 @@ const RepeatableShifts = () => {
             placeholder="e.g., Morning Shift"
           />
         </label>
-        <br />
         <label>
           Start Time:
           <input
@@ -84,7 +94,6 @@ const RepeatableShifts = () => {
             onChange={handleInputChange}
           />
         </label>
-        <br />
         <label>
           End Time:
           <input
@@ -94,7 +103,6 @@ const RepeatableShifts = () => {
             onChange={handleInputChange}
           />
         </label>
-        <br />
         <label>
           Required Volunteers:
           <input
@@ -105,7 +113,6 @@ const RepeatableShifts = () => {
             min="1"
           />
         </label>
-        <br />
         <label>
           Max Volunteers:
           <input
@@ -116,77 +123,78 @@ const RepeatableShifts = () => {
             min="1"
           />
         </label>
-        <br />
-        <button type="submit" style={{ marginTop: "10px" }}>
-          Add Shift
-        </button>
-        {successMessage && <p style={{ color: "green", marginTop: "10px" }}>{successMessage}</p>}
+        <button type="submit" className="submit-button">Add Shift</button>
       </form>
-      {/* List of shifts */}
       <div>
         <h3>Current Repeatable Shifts</h3>
         {shifts.length === 0 ? (
           <p>No shifts added yet.</p>
         ) : (
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
-            <thead>
-              <tr>
-                <th>Shift Name</th>
-                <th>Start Time</th>
-                <th>End Time</th>
-                <th>Required Volunteers</th>
-                <th>Max Volunteers</th>
-                <th>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {shifts.map((shift, index) => (
-                <tr key={index}>
-                  <td>
-                    <input
-                      type="text"
-                      value={shift.shiftName}
-                      onChange={(e) => updateShift(index, "shiftName", e.target.value)}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="time"
-                      value={shift.startTime}
-                      onChange={(e) => updateShift(index, "startTime", e.target.value)}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="time"
-                      value={shift.endTime}
-                      onChange={(e) => updateShift(index, "endTime", e.target.value)}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="number"
-                      min="1"
-                      value={shift.requiredVolunteers}
-                      onChange={(e) => updateShift(index, "requiredVolunteers", e.target.value)}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="number"
-                      min="1"
-                      value={shift.maxVolunteers}
-                      onChange={(e) => updateShift(index, "maxVolunteers", e.target.value)}
-                    />
-                  </td>
-                  <td>
-                    <button onClick={() => deleteShift(index)}>Delete</button>
-                  </td>
+          <>
+            <table className="shift-table">
+              <thead>
+                <tr>
+                  <th>Shift Name</th>
+                  <th>Start Time</th>
+                  <th>End Time</th>
+                  <th>Required Volunteers</th>
+                  <th>Max Volunteers</th>
+                  <th>Action</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {shifts.map((shift, index) => (
+                  <tr key={index}>
+                    <td>
+                      <input
+                        type="text"
+                        value={shift.shiftName}
+                        onChange={(e) => updateShift(index, "shiftName", e.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="time"
+                        value={shift.startTime}
+                        onChange={(e) => updateShift(index, "startTime", e.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="time"
+                        value={shift.endTime}
+                        onChange={(e) => updateShift(index, "endTime", e.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="number"
+                        min="1"
+                        value={shift.requiredVolunteers}
+                        onChange={(e) => updateShift(index, "requiredVolunteers", e.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="number"
+                        min="1"
+                        value={shift.maxVolunteers}
+                        onChange={(e) => updateShift(index, "maxVolunteers", e.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <button onClick={() => deleteShift(index)}>Delete</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <button className="submit-button" onClick={handleSubmitAllShifts}>
+              Submit Schedule
+            </button>
+          </>
         )}
+        {successMessage && <p className="success-message">{successMessage}</p>}
       </div>
     </div>
   );

--- a/client_app/src/components/shelter/Settings.js
+++ b/client_app/src/components/shelter/Settings.js
@@ -10,7 +10,6 @@ const Settings = () => {
     <div className="settings-page">
       <h2>Settings</h2>
       <AddUserForm shelterId={shelterId} />
-
       {/* Add link to define repeatable shifts */}
       <Link to={`/shelter-dashboard/${shelterId}/repeatable-shifts`}>
         <button>Define Repeatable Shifts</button>

--- a/client_app/src/components/shelter/Settings.js
+++ b/client_app/src/components/shelter/Settings.js
@@ -1,6 +1,6 @@
 // client_app/src/components/shelter/Settings.js
 import React from "react";
-import { useParams } from "react-router-dom";
+import { useParams, Link } from "react-router-dom"; // Added Link
 import AddUserForm from "./AddUserForm";
 
 const Settings = () => {
@@ -10,6 +10,11 @@ const Settings = () => {
     <div className="settings-page">
       <h2>Settings</h2>
       <AddUserForm shelterId={shelterId} />
+
+      {/* Add link to define repeatable shifts */}
+      <Link to={`/shelter-dashboard/${shelterId}/repeatable-shifts`}>
+        <button>Define Repeatable Shifts</button>
+      </Link>
     </div>
   );
 };

--- a/client_app/src/styles/shelter/RepeatableShifts.css
+++ b/client_app/src/styles/shelter/RepeatableShifts.css
@@ -1,0 +1,76 @@
+.repeatable-shifts-page {
+    max-width: 700px;
+    margin: 40px auto;
+    padding: 20px;
+    font-family: sans-serif;
+    background-color: #f9f9f9;
+    border-radius: 12px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  }
+  
+  .repeatable-shifts-page h2,
+  .repeatable-shifts-page h3 {
+    text-align: center;
+    color: #333;
+    margin-bottom: 20px;
+  }
+  
+  form label {
+    display: block;
+    margin-bottom: 10px;
+    color: #555;
+  }
+  
+  form input[type="text"],
+  form input[type="time"] {
+    width: 100%;
+    padding: 8px;
+    margin-top: 4px;
+    margin-bottom: 16px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    box-sizing: border-box;
+  }
+  
+  form button {
+    display: block;
+    width: 100%;
+    padding: 10px;
+    background-color: #1e88e5;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: bold;
+    margin-top: 10px;
+  }
+  
+  form button:hover {
+    background-color: #1565c0;
+  }
+  
+  .shift-item {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 10px;
+  }
+  
+  .shift-item input[type="text"],
+  .shift-item input[type="time"] {
+    flex: 1;
+  }
+  
+  .shift-item button {
+    padding: 6px 10px;
+    background-color: #e53935;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  
+  .shift-item button:hover {
+    background-color: #c62828;
+  }
+  

--- a/client_app/src/styles/shelter/RepeatableShifts.css
+++ b/client_app/src/styles/shelter/RepeatableShifts.css
@@ -1,76 +1,120 @@
 .repeatable-shifts-page {
-    max-width: 700px;
-    margin: 40px auto;
-    padding: 20px;
-    font-family: sans-serif;
-    background-color: #f9f9f9;
-    border-radius: 12px;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-  }
-  
-  .repeatable-shifts-page h2,
-  .repeatable-shifts-page h3 {
-    text-align: center;
-    color: #333;
-    margin-bottom: 20px;
-  }
-  
-  form label {
-    display: block;
-    margin-bottom: 10px;
-    color: #555;
-  }
-  
-  form input[type="text"],
-  form input[type="time"] {
-    width: 100%;
-    padding: 8px;
-    margin-top: 4px;
-    margin-bottom: 16px;
-    border: 1px solid #ccc;
-    border-radius: 6px;
-    box-sizing: border-box;
-  }
-  
-  form button {
-    display: block;
-    width: 100%;
-    padding: 10px;
-    background-color: #1e88e5;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-weight: bold;
-    margin-top: 10px;
-  }
-  
-  form button:hover {
-    background-color: #1565c0;
-  }
-  
-  .shift-item {
-    display: flex;
-    gap: 10px;
-    align-items: center;
-    margin-bottom: 10px;
-  }
-  
-  .shift-item input[type="text"],
-  .shift-item input[type="time"] {
-    flex: 1;
-  }
-  
-  .shift-item button {
-    padding: 6px 10px;
-    background-color: #e53935;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-  }
-  
-  .shift-item button:hover {
-    background-color: #c62828;
-  }
-  
+  max-width: 900px; /* updated from 700px */
+  margin: 40px auto;
+  padding: 20px;
+  font-family: sans-serif;
+  background-color: #f9f9f9;
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.repeatable-shifts-page h2,
+.repeatable-shifts-page h3 {
+  text-align: center;
+  color: #333;
+  margin-bottom: 20px;
+}
+
+.instructions {
+  font-size: 0.95rem;
+  color: #444;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.shift-form {
+  margin-bottom: 20px;
+}
+
+form label {
+  display: block;
+  margin-bottom: 10px;
+  color: #555;
+}
+
+form input[type="text"],
+form input[type="time"],
+form input[type="number"] {
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
+  margin-bottom: 16px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+
+form button,
+.submit-button {
+  display: block;
+  width: 100%;
+  padding: 10px;
+  background-color: #1e88e5;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: bold;
+  margin-top: 10px;
+  text-align: center;
+}
+
+form button:hover,
+.submit-button:hover {
+  background-color: #1565c0;
+}
+
+.success-message {
+  color: green;
+  margin-top: 10px;
+  text-align: center;
+  font-weight: 500;
+}
+
+.shift-item {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.shift-item input[type="text"],
+.shift-item input[type="time"] {
+  flex: 1;
+}
+
+.shift-item button {
+  padding: 6px 10px;
+  background-color: #e53935;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.shift-item button:hover {
+  background-color: #c62828;
+}
+
+.shift-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+.shift-table th,
+.shift-table td {
+  padding: 8px;
+  border: 1px solid #ccc;
+  text-align: left;
+}
+
+.shift-table input[type="text"],
+.shift-table input[type="time"],
+.shift-table input[type="number"] {
+  width: 100%;
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
Pull request for Issue 253 repeatable shifts 

What was changed?
Added a new route for defining repeatable shifts (/shelter-dashboard/:shelterId/repeatable-shifts).

Updated the Settings.js file to include a button link that navigates to the Repeatable Shifts page.

Created a placeholder for the RepeatableShifts component (if you did).

Why was it changed?
Shelter admins need the ability to define repeatable shifts easily from the dashboard.

This functionality helps streamline shift scheduling and reduces manual entry for common daily schedules.

How was it changed?
Modified client_app/src/components/shelter/Settings.js:

Added a <Link> that routes to /shelter-dashboard/:shelterId/repeatable-shifts with a Define Repeatable Shifts button.

Modified client_app/src/App.js:

Imported RepeatableShifts and added a new <Route> inside the <ShelterDashboardLayout> route group.
