### PR TITLE
added post/scheduling api endpoints

### DIFF
--- a/server/application/rest/schedule.py
+++ b/server/application/rest/schedule.py
@@ -25,14 +25,14 @@ def create_schedule():
             #making sure the shift has required fields
             if 'timestamp' not in shift or 'service' not in shift:
                 return jsonify({'error'
-                                : 'Each shift must have timestamp and service fields'}),
+                                : 'Shift requires timestamp + service fields'}),
                 400
             #timestamp here is "milliseconds since midnight" instead of epoch
-            # check this, trying to insert the shift into the schedule collection
+            # check this, trying to insert shift into  schedule collection
             result = schedule_repo.insert(shift)
             inserted_ids.append(str(result))
         #return success with the IDs of created schedules
-        return jsonify({'message': 'Schedule created successfully', 
+        return jsonify({'message': 'Schedule created successfully',
                         'ids': inserted_ids}), 201
     except Exception as e:
         return jsonify({'error': str(e)}), 500

--- a/server/application/rest/schedule.py
+++ b/server/application/rest/schedule.py
@@ -18,19 +18,22 @@ def create_schedule():
         #parsing the request body as JSON
         shifts = request.get_json()
         if not shifts or not isinstance(shifts, list):
-            return jsonify({'error': 'Expected a list of service shifts'}), 400  
+            return jsonify({'error': 'Expected a list of service shifts'}), 400
         #going to process every shift
         inserted_ids = []
         for shift in shifts:
             #making sure the shift has required fields
             if 'timestamp' not in shift or 'service' not in shift:
-                return jsonify({'error': 'Each shift must have timestamp and service fields'}), 400
-            #timestamp here is "milliseconds since midnight" instead of epoch            
+                return jsonify({'error'
+                                : 'Each shift must have timestamp and service fields'}),
+                400
+            #timestamp here is "milliseconds since midnight" instead of epoch
             # check this, trying to insert the shift into the schedule collection
             result = schedule_repo.insert(shift)
             inserted_ids.append(str(result))
         #return success with the IDs of created schedules
-        return jsonify({'message': 'Schedule created successfully', 'ids': inserted_ids}), 201
+        return jsonify({'message': 'Schedule created successfully', 
+                        'ids': inserted_ids}), 201
     except Exception as e:
         return jsonify({'error': str(e)}), 500
     

--- a/server/application/rest/schedule.py
+++ b/server/application/rest/schedule.py
@@ -1,0 +1,36 @@
+"""
+module for handling the schedule endpoint
+"""
+from flask import request, jsonify
+from application.rest import app
+from repository.mongo.service_shifts import ServiceShiftsMongoRepo
+
+#new instance of the repo with the schedule collection
+schedule_repo = ServiceShiftsMongoRepo(collection_name='schedule')
+
+@app.route('/schedule', methods=['POST'])
+def create_schedule():
+    """
+    endpoint to create repeatable schedule templates.
+    wants a JSON array of service shift objects.
+    """
+    try:
+        #parsing the request body as JSON
+        shifts = request.get_json()
+        if not shifts or not isinstance(shifts, list):
+            return jsonify({'error': 'Expected a list of service shifts'}), 400  
+        #going to process every shift
+        inserted_ids = []
+        for shift in shifts:
+            #making sure the shift has required fields
+            if 'timestamp' not in shift or 'service' not in shift:
+                return jsonify({'error': 'Each shift must have timestamp and service fields'}), 400
+            #timestamp here is "milliseconds since midnight" instead of epoch            
+            # check this, trying to insert the shift into the schedule collection
+            result = schedule_repo.insert(shift)
+            inserted_ids.append(str(result))
+        #return success with the IDs of created schedules
+        return jsonify({'message': 'Schedule created successfully', 'ids': inserted_ids}), 201
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+    


### PR DESCRIPTION
Fixes #250 

Created a new endpoint for handling repeatable schedules. The implementation stores schedule templates in a dedicated collection and reuses our existing service shift code. need to still add tests and implement the schedule generation functionality do actual create the service shifts from the template 

