### PR TITLE
added an optional URL parameter to GET /service_commitment endpoint. …

### DIFF
--- a/server/application/rest/request_parameters.py
+++ b/server/application/rest/request_parameters.py
@@ -1,0 +1,2 @@
+def is_true(request_args, param_name):
+    return request_args.get(param_name, "").lower() == "true"

--- a/server/application/rest/request_parameters.py
+++ b/server/application/rest/request_parameters.py
@@ -1,2 +1,11 @@
+"""
+This module contains supporting functions for parsing URL parameters
+"""
 def is_true(request_args, param_name):
+    """
+    Check if a parameter in the request arguments is set to "true".
+    :param request_args: The request arguments dictionary.
+    :param param_name: The name of the parameter to check.
+    :return: True if the parameter is set to "true", False otherwise.
+    """
     return request_args.get(param_name, "").lower() == "true"

--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -8,17 +8,23 @@ from domains.service_commitment import ServiceCommitment
 
 from authentication.authenticate_user import get_user_from_token
 from application.rest.status_codes import HTTP_STATUS_CODES_MAPPING
+from application.rest.request_parameters import is_true
 from use_cases.add_service_commitments import add_service_commitments
 from use_cases.list_service_commitments import list_service_commitments
+from use_cases.list_shelters_for_shifts import list_shelters_for_shifts
 from repository.mongo.service_commitments import MongoRepoCommitments
 from repository.mongo.service_shifts import ServiceShiftsMongoRepo
+from repository.mongo.shelter import ShelterRepo
 from serializers.service_commitment import ServiceCommitmentJsonEncoder
+from serializers.service_shift import ServiceShiftJsonEncoder
+from serializers.shelter import ShelterJsonEncoder
 from responses import ResponseTypes
 
 service_commitment_bp = Blueprint("service_commitment", __name__)
 
 commitments_repo = MongoRepoCommitments()
 shifts_repo = ServiceShiftsMongoRepo()
+shelter_repo = ShelterRepo()
 
 @service_commitment_bp.route("/service_commitment", methods=["POST"])
 def create_service_commitment():
@@ -82,7 +88,12 @@ def fetch_service_commitments():
     try:
         # Extract service_shift_id from query parameters if provided
         service_shift_id = request.args.get("service_shift_id")
+        include_shift_details = is_true(request.args, "include_shift_details")
+        print("WE ARE HERE")
+        print(request.headers)
         user_tuple = get_user_from_token(request.headers)
+        print("user tuple is ", user_tuple)
+        print("HERE NOW")
         # get_user_from_token returns a tuple of (email, first_name, last_name)
         if not user_tuple or not isinstance(user_tuple, tuple):
             return (
@@ -101,11 +112,12 @@ def fetch_service_commitments():
         # view all volunteers
         # If service_shift_id is not provided, we filter by user_email as before
         filter_user = None if service_shift_id else user_email
-        commitments, _ = list_service_commitments(
+        commitments, shifts = list_service_commitments(
             commitments_repo,
             shifts_repo,
             filter_user,
-            service_shift_id)
+            service_shift_id
+            )
 
         # Convert commitments to JSON
         commitments_list = []
@@ -113,9 +125,48 @@ def fetch_service_commitments():
             commitment_dict = json.loads(json.dumps(
                 commitment, cls=ServiceCommitmentJsonEncoder))
             commitments_list.append(commitment_dict)
+
+        if include_shift_details:
+            shelters = list_shelters_for_shifts(shifts, shelter_repo)
+            # Confirt shifts to JSON
+            shifts_list = []
+            for shift in shifts:
+                shift_dict = json.loads(json.dumps(
+                    shift, cls=ServiceShiftJsonEncoder))
+                shifts_list.append(shift_dict)
+            # Convert shelters to JSON
+            shelters_list = []
+            for shelter in shelters:
+                shelter_dict = json.loads(json.dumps(
+                    shelter, cls=ShelterJsonEncoder))
+                shelters_list.append(shelter_dict)
+
+            # merge the commitments_list, shifts_list 
+            # there is the same number of elements in each list
+            # augment the data in commitments_list with the shift and shelter data
+            # by copying the fields of shift into the commitment
+            # for example, if we have 
+            # commitment data as  {shelter_id = 'some id', volunteer_id = 'volunteer'}
+            # shift data as {shelter_id = 'some id', shift_start = 'start time'}
+            # we will have
+            # commitment data as {shelter_id = 'some id', volunteer_id = 'volunteer', shift_start = 'start time'}
+            for i in range(len(commitments_list)):
+                commitments_list[i].update({**shifts_list[i]})
+            # merge the shelters data into the commitments_list
+            # shelter_list might not be the same size as commitments_list because there may be multiple
+            # commitments for the same shelter
+            # so we will have to check if the shelter_id is the same
+            # and then merge the data
+            # add a new field: shelter in the commitment data
+            shelters_dict = {shelter['_id']: shelter for shelter in shelters_list}
+            for commitment in commitments_list:
+                shelter_id = commitment.get('shelter_id')
+                if shelter_id in shelters_dict:
+                    commitment.update({"shelter": shelters_dict[shelter_id]})
         return Response(
             json.dumps(
-                {"success": True, "results": commitments_list}, default=str),
+                commitments_list, default=str
+            ),
             mimetype="application/json",
             status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS])
     except ValueError as error:

--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -128,7 +128,7 @@ def fetch_service_commitments():
 
         if include_shift_details:
             shelters = list_shelters_for_shifts(shifts, shelter_repo)
-            # Confirt shifts to JSON
+            # Convert shifts to JSON
             shifts_list = []
             for shift in shifts:
                 shift_dict = json.loads(json.dumps(

--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -149,7 +149,7 @@ def fetch_service_commitments():
                 commitments_list[i].update({**shifts_list[i]})
 
             # merge the shelters data into the commitments_list
-            # shelter_list might not be the same size as commitments_list 
+            # shelter_list might not be the same size as commitments_list
             # because there may be multiple commitments for the same shelter
             # so we will have to check if the shelter_id is the same
             # and then merge the data
@@ -158,7 +158,7 @@ def fetch_service_commitments():
                 shelter["_id"]: shelter for shelter in shelters_list
             }
             for commitment in commitments_list:
-                shelter_id = commitment.get('shelter_id')
+                shelter_id = commitment.get("shelter_id")
                 if shelter_id in shelters_dict:
                     commitment.update({"shelter": shelters_dict[shelter_id]})
         return Response(

--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -89,11 +89,7 @@ def fetch_service_commitments():
         # Extract service_shift_id from query parameters if provided
         service_shift_id = request.args.get("service_shift_id")
         include_shift_details = is_true(request.args, "include_shift_details")
-        print("WE ARE HERE")
-        print(request.headers)
         user_tuple = get_user_from_token(request.headers)
-        print("user tuple is ", user_tuple)
-        print("HERE NOW")
         # get_user_from_token returns a tuple of (email, first_name, last_name)
         if not user_tuple or not isinstance(user_tuple, tuple):
             return (

--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -141,24 +141,22 @@ def fetch_service_commitments():
                     shelter, cls=ShelterJsonEncoder))
                 shelters_list.append(shelter_dict)
 
-            # merge the commitments_list, shifts_list 
+            # merge the commitments_list, shifts_list
             # there is the same number of elements in each list
-            # augment the data in commitments_list with the shift and shelter data
-            # by copying the fields of shift into the commitment
-            # for example, if we have 
-            # commitment data as  {shelter_id = 'some id', volunteer_id = 'volunteer'}
-            # shift data as {shelter_id = 'some id', shift_start = 'start time'}
-            # we will have
-            # commitment data as {shelter_id = 'some id', volunteer_id = 'volunteer', shift_start = 'start time'}
+            # augment the data in commitments_list with the shifts data
+            # by copying the fields of each shift into the commitment
             for i in range(len(commitments_list)):
                 commitments_list[i].update({**shifts_list[i]})
+
             # merge the shelters data into the commitments_list
-            # shelter_list might not be the same size as commitments_list because there may be multiple
-            # commitments for the same shelter
+            # shelter_list might not be the same size as commitments_list 
+            # because there may be multiple commitments for the same shelter
             # so we will have to check if the shelter_id is the same
             # and then merge the data
             # add a new field: shelter in the commitment data
-            shelters_dict = {shelter['_id']: shelter for shelter in shelters_list}
+            shelters_dict = {
+                shelter["_id"]: shelter for shelter in shelters_list
+            }
             for commitment in commitments_list:
                 shelter_id = commitment.get('shelter_id')
                 if shelter_id in shelters_dict:

--- a/server/tests/rest/service_commitment/test_service_commitment.py
+++ b/server/tests/rest/service_commitment/test_service_commitment.py
@@ -1,4 +1,6 @@
-import json
+"""
+Test cases for the service commitment API endpoints.
+"""
 import pytest
 
 from unittest.mock import patch
@@ -46,7 +48,7 @@ def test_get_commitments_with_augmented_data(
         ServiceCommitment.from_dict(commitment)
         for commitment in mock_commitments_json
     ]
-    
+
     mock_shifts_json = [
         {
             "_id": "SHIFT_ID1",

--- a/server/tests/rest/service_commitment/test_service_commitment.py
+++ b/server/tests/rest/service_commitment/test_service_commitment.py
@@ -1,0 +1,126 @@
+import json
+import pytest
+
+from unittest.mock import patch
+from flask import Flask
+from application.rest.service_commitment import service_commitment_bp
+from domains.service_commitment import ServiceCommitment
+from domains.service_shift import ServiceShift
+from domains.shelter.shelter import Shelter
+
+def create_test_app():
+    app = Flask(__name__)
+    app.register_blueprint(service_commitment_bp)
+    return app
+
+@pytest.fixture
+def client():
+    app = create_test_app()
+    app.config["TESTING"] = True
+    return app.test_client()
+
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+
+@patch("application.rest.service_commitment.list_service_commitments")
+@patch("application.rest.service_commitment.list_shelters_for_shifts")
+@patch("application.rest.service_commitment.get_user_from_token")
+def test_get_commitments_with_augmented_data(
+    mock_get_user_from_token,
+    mock_list_shelters_for_shifts,
+    mock_list_service_commitments,
+    client):
+    mock_commitments_json = [
+        {
+            "_id": "SOME_ID1",
+            "service_shift_id": "SHIFT_ID1",
+            "volunteer_id": "VOLUNTEER_ID1",
+        },
+        {
+            "_id": "SOME_ID2",
+            "service_shift_id": "SHIFT_ID2",
+            "volunteer_id": "VOLUNTEER_ID2",
+        },
+    ]
+    mock_commitments = [
+        ServiceCommitment.from_dict(commitment)
+        for commitment in mock_commitments_json
+    ]
+    
+    mock_shifts_json = [
+        {
+            "_id": "SHIFT_ID1",
+            "shelter_id": "SHELTER_ID1",
+            "shift_start": "10000",
+            "shift_end": "20000",
+            "required_volunteer_count": 1,
+            "max_volunteer_count": 5,
+            "shift_name": "Morning Shift",
+            "can_sign_up": True,
+            # Other shift details...
+        },
+        {
+            "_id": "SHIFT_ID2",
+            "shelter_id": "SHELTER_ID2",
+            "shift_start": "50000",
+            "shift_end": "60000",
+            "required_volunteer_count": 1,
+            "max_volunteer_count": 5,
+            "shift_name": "Evening Shift",
+            "can_sign_up": True,
+            # Other shift details...
+        },
+    ]
+
+    mock_shifts = [
+        ServiceShift.from_dict(shift)
+        for shift in mock_shifts_json
+    ]
+    mock_shelters_json = [
+        {
+            "_id": "SHELTER_ID1",
+            "name": "Shelter 1",
+            "address": {
+                "street1": "123 Main St",
+                "city": "Cityville",
+                "state": "State",
+                "postalCode": "12345",
+            },
+            # Other shelter details...
+        },
+        {
+            "_id": "SHELTER_ID2",
+            "name": "Shelter 2",
+            "address": {
+                "street1": "456 Elm St",
+                "city": "Townsville",
+                "state": "State",
+                "postalCode": "67890",
+            },
+            # Other shelter details...
+        },
+    ]
+    mock_shelters = [
+        Shelter.from_dict(shelter)
+        for shelter in mock_shelters_json
+    ]
+    mock_user = ("user@user.com", "FirstName", "LastName")
+
+    mock_list_service_commitments.return_value = (mock_commitments, mock_shifts)
+    mock_list_shelters_for_shifts.return_value = mock_shelters
+    mock_get_user_from_token.return_value = mock_user
+
+    print(mock_list_service_commitments.return_value)
+    response = client.get("/service_commitment?include_shift_details=true")
+    assert mock_get_user_from_token.called
+    for i in range(len(mock_commitments_json)):
+        mock_commitments_json[i].update({**mock_shifts_json[i]})
+        mock_commitments_json[i].update({"shelter": mock_shelters_json[i]})
+    assert response.status_code == 200
+    assert response.json == mock_commitments_json
+    assert mock_list_service_commitments.called
+    assert mock_list_shelters_for_shifts.called
+    mock_list_service_commitments.assert_called_once()
+    mock_list_shelters_for_shifts.assert_called_once()
+# pylint: enable=unused-argument
+# pylint: enable=redefined-outer-name

--- a/server/use_cases/list_shelters_for_shifts.py
+++ b/server/use_cases/list_shelters_for_shifts.py
@@ -1,0 +1,23 @@
+"""
+Use case for listing shelters associated with service shifts.
+"""
+def list_shelters_for_shifts(service_shifts, shelter_repo):
+    """
+    Retrieves shifts and shelters associated with service commitments.
+
+    Args:
+        service_shifts: A list of service shifts
+        shelter_repo: The repository for accessing shelters.
+
+    Returns:
+        tuple: A tuple containing a list of shifts and a list of shelters.
+    """
+
+    shelters = []
+    
+    for shift in service_shifts:
+        shelter = shelter_repo.get_by_id(shift.shelter_id)
+        if shelter and shelter not in shelters:
+            shelters.append(shelter)
+
+    return shelters

--- a/server/use_cases/list_shelters_for_shifts.py
+++ b/server/use_cases/list_shelters_for_shifts.py
@@ -14,7 +14,7 @@ def list_shelters_for_shifts(service_shifts, shelter_repo):
     """
 
     shelters = []
-    
+
     for shift in service_shifts:
         shelter = shelter_repo.get_by_id(shift.shelter_id)
         if shelter and shelter not in shelters:


### PR DESCRIPTION
Fixes #269

**What was changed?**

Updated GET /service_commitment API endpoint to accept a parameter:
* include_shift_details: takes on the value of true or false. 
If true, the returned data will be augmented with shifts data (all shift details will be merged into the commitments JSON). Additionally, the commitments JSON object will contain a 'shelter" field with shelter information.

**Why was it changed?**

When volunteers retrieve their commitments, they will need to know what time and where they need to be.

**How was it changed?**

Updated `application/rest/service_commitment.py` file to look for the optional parameter. If the parameter is present, call the list_shelters_for_shifts use case and merge all the resulting data together.
Also added a test case for a scenario where we call GET /service_commitment?include_shift_details=true

