### PR TITLE
added time filtering to GET /service_commitment API endpoint

### DIFF
--- a/server/application/rest/request_parameters.py
+++ b/server/application/rest/request_parameters.py
@@ -1,8 +1,10 @@
-from request.time_filter import build_time_filter
-import re
 """
 This module contains supporting functions for parsing URL parameters
+and building request objects for the API.
 """
+from request.time_filter import build_time_filter
+import re
+
 def is_true(request_args, param_name):
     """
     Check if a parameter in the request arguments is set to "true".

--- a/server/application/rest/request_parameters.py
+++ b/server/application/rest/request_parameters.py
@@ -1,3 +1,5 @@
+from request.time_filter import build_time_filter
+import re
 """
 This module contains supporting functions for parsing URL parameters
 """
@@ -9,3 +11,16 @@ def is_true(request_args, param_name):
     :return: True if the parameter is set to "true", False otherwise.
     """
     return request_args.get(param_name, "").lower() == "true"
+
+def get_time_filters(request_args):
+    """
+    Extract time filters from the request arguments.
+    :param request_args: The request arguments dictionary.
+    :return: A dictionary containing the time filters.
+    """
+    time_filters = {}
+    for arg, values in request_args.items():
+        if arg.startswith("filter_"):
+            time_filters[re.sub("filter_", "", arg)] = values
+    # convert time_filters to TimeFilter object
+    return build_time_filter(time_filters)

--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -16,7 +16,6 @@ from use_cases.list_shelters_for_shifts import list_shelters_for_shifts
 from repository.mongo.service_commitments import MongoRepoCommitments
 from repository.mongo.service_shifts import ServiceShiftsMongoRepo
 from repository.mongo.shelter import ShelterRepo
-from request.time_filter import build_time_filter
 from serializers.service_commitment import ServiceCommitmentJsonEncoder
 from serializers.service_shift import ServiceShiftJsonEncoder
 from serializers.shelter import ShelterJsonEncoder
@@ -85,39 +84,6 @@ def create_service_commitment():
 def fetch_service_commitments():
     """
     Handle GET request to retrieve service commitments.
-
-    This endpoint retrieves service commitments, optionally filtered by a specific
-    service shift ID or user email (extracted from the authorization token). It can
-    also include additional details about shifts and shelters if requested.
-
-    Query Parameters:
-    - service_shift_id (str, optional): The ID of the service shift to filter commitments.
-    - include_shift_details (bool, optional): Whether to include details about shifts and shelters.
-
-    Headers:
-    - Authorization (str): Bearer token for user authentication.
-
-    Responses:
-    - 200 OK: Returns a list of service commitments, optionally augmented with shift and shelter details.
-    - 400 Bad Request: Returns an error message if the request parameters are invalid.
-    - 401 Unauthorized: Returns an error message if the authorization token is invalid.
-
-    Example Response (200 OK):
-    [
-        {
-            "commitment_id": "12345",
-            "volunteer_id": "user@example.com",
-            "service_shift_id": "67890",
-            "shelter_id": "54321",
-            "shift_start_time": "2023-01-01T08:00:00Z",
-            "shift_end_time": "2023-01-01T12:00:00Z",
-            "shelter": {
-                "shelter_id": "54321",
-                "name": "Happy Paws Shelter",
-                "location": "123 Main St, Cityville"
-            }
-        }
-    ]
     """
     try:
         # Extract service_shift_id from query parameters if provided

--- a/server/domains/service_commitment.py
+++ b/server/domains/service_commitment.py
@@ -3,8 +3,8 @@ This module defines the ServiceCommitment
 class, which represents a volunteer's commitment to a ServiceShift.
 """
 
-import uuid
 import dataclasses
+from typing import Optional
 
 @dataclasses.dataclass
 class ServiceCommitment:
@@ -14,8 +14,8 @@ class ServiceCommitment:
     Represents a volunteer signing up for a specific ServiceShift.
     """
     volunteer_id: str  # Typically an email address
-    service_shift_id: uuid.UUID  # The ID of the associated ServiceShift
-    _id: uuid.UUID = None  # Unique ID for this commitment
+    service_shift_id: str  # The ID of the associated ServiceShift
+    _id: Optional[str] = None  # Unique ID for this commitment
 
     def get_id(self):
         """Returns the ID of the service shift."""

--- a/server/domains/service_shift.py
+++ b/server/domains/service_shift.py
@@ -3,7 +3,7 @@ This module handles data conversion from
 dictionary to class obj or vice versa.
 """
 import dataclasses
-import uuid
+from typing import Optional
 
 @dataclasses.dataclass
 
@@ -18,7 +18,7 @@ class ServiceShift:
     required_volunteer_count: int = 1
     max_volunteer_count: int = 5
     can_sign_up: bool = True
-    _id: uuid.UUID = None
+    _id: Optional[str] = None
 
     def get_id(self):
         """Returns the ID of the service shift."""

--- a/server/repository/mongo/service_commitments.py
+++ b/server/repository/mongo/service_commitments.py
@@ -33,7 +33,7 @@ class MongoRepoCommitments:
         for commitment in commitments:
             commitment.pop('_id', None)
         result = self.collection.insert_many(commitments)
-        return result.inserted_ids
+        return [str(inserted_id) for inserted_id in result.inserted_ids]
 
     def fetch_service_commitments(self, user_id=None, shift_id =None):
         """

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -76,6 +76,8 @@ class ServiceShiftsMongoRepo:
             ServiceShift.from_dict(shift)
             for shift in self.collection.find(db_filter)
         ]
+        for shift in service_shifts:
+            shift["_id"] = str(shift["_id"])
         return service_shifts
 
     def get_shifts(self, shift_ids):
@@ -91,6 +93,8 @@ class ServiceShiftsMongoRepo:
         try:
             object_ids = [ObjectId(sid) for sid in shift_ids]
             shifts = list(self.collection.find({"_id": {"$in": object_ids}}))
+            for shift in shifts:
+                shift["_id"] = str(shift["_id"])
             return [ServiceShift.from_dict(shift) for shift in shifts]
         except Exception as e:
             raise ValueError(f"Invalid shift ID: {e}") from e

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -77,7 +77,7 @@ class ServiceShiftsMongoRepo:
             for shift in self.collection.find(db_filter)
         ]
         for shift in service_shifts:
-            shift["_id"] = str(shift["_id"])
+            shift.set_id(str(shift.get_id()))
         return service_shifts
 
     def get_shifts(self, shift_ids):
@@ -94,7 +94,7 @@ class ServiceShiftsMongoRepo:
             object_ids = [ObjectId(sid) for sid in shift_ids]
             shifts = list(self.collection.find({"_id": {"$in": object_ids}}))
             for shift in shifts:
-                shift["_id"] = str(shift["_id"])
+                shift.set_id(str(shift.get_id()))
             return [ServiceShift.from_dict(shift) for shift in shifts]
         except Exception as e:
             raise ValueError(f"Invalid shift ID: {e}") from e

--- a/server/request/time_filter.py
+++ b/server/request/time_filter.py
@@ -1,3 +1,9 @@
+"""
+TimeFilter class and build_time_filter function.
+This module contains the TimeFilter class and a function to build it.
+The TimeFilter class is used to encapsulate time-related filters 
+for service commitments and service shifts
+"""
 from collections.abc import Mapping
 class TimeFilter:
     """
@@ -12,7 +18,7 @@ class TimeFilter:
         return self.filters
     def get_filter(self, key):
         return self.filters.get(key) if self.filters else None
-    
+
 def build_time_filter(filters=None):
     """
     Build a TimeFilter object.
@@ -40,9 +46,9 @@ def build_time_filter(filters=None):
                 )
             try:
                 converted_filters[key] = int(value)
-            except ValueError:
-                raise (
-                    ValueError("filters", f"Value of {key} must be an integer")
-                )
+            except ValueError as exc:
+                raise ValueError(
+                        "filters", f"Value of {key} must be an integer"
+                    ) from exc
 
     return TimeFilter(filters=converted_filters)

--- a/server/request/time_filter.py
+++ b/server/request/time_filter.py
@@ -1,0 +1,48 @@
+from collections.abc import Mapping
+class TimeFilter:
+    """
+    Request object passed to the list_service_commitments use case.
+    """
+    def __init__(self, filters=None):
+        self.filters = filters
+
+    def __bool__(self):
+        return True
+    def get_filters(self):
+        return self.filters
+    def get_filter(self, key):
+        return self.filters.get(key) if self.filters else None
+    
+def build_time_filter(filters=None):
+    """
+    Build a TimeFilter object.
+
+    Args:
+        filters (dict): Optional filters for the request.
+
+    Returns:
+        TimeFilter: The constructed time filter object.
+    """
+    accepted_filters = [
+        "start_after", "start_before"
+    ]
+    converted_filters = {}
+    if filters is not None:
+        if not isinstance(filters, Mapping):
+            raise (
+                TypeError("filters must be an iterable")
+            )
+
+        for key, value in filters.items():
+            if key not in accepted_filters:
+                raise (
+                    KeyError(f"Key {key} cannot be used")
+                )
+            try:
+                converted_filters[key] = int(value)
+            except ValueError:
+                raise (
+                    ValueError("filters", f"Value of {key} must be an integer")
+                )
+
+    return TimeFilter(filters=converted_filters)

--- a/server/tests/use_cases/service_commitments/test_list_commitments.py
+++ b/server/tests/use_cases/service_commitments/test_list_commitments.py
@@ -4,6 +4,7 @@ Tests for listing service commitments
 
 from unittest.mock import MagicMock
 from use_cases.list_service_commitments import list_service_commitments
+from request.time_filter import TimeFilter
 
 class FakeCommitment:
     def __init__(self, service_shift_id, user_email):
@@ -19,7 +20,7 @@ def test_list_service_commitments_no_commitments():
 
     user_email = "test@example.com"
     commitments, shifts = list_service_commitments(
-        commitments_repo, shifts_repo, user_email
+        commitments_repo, shifts_repo, TimeFilter(None), user_email
     )
 
     assert commitments == []
@@ -42,7 +43,7 @@ def test_list_service_commitments_with_commitments():
 
     user_email = "test@example.com"
     commitments, shifts = list_service_commitments(
-        commitments_repo, shifts_repo, user_email
+        commitments_repo, shifts_repo, TimeFilter(None), user_email
     )
 
     assert len(commitments) == 2

--- a/server/use_cases/list_service_commitments.py
+++ b/server/use_cases/list_service_commitments.py
@@ -2,7 +2,7 @@
 This module contains the use case for listing service commitments.
 """
 def list_service_commitments(
-        commitments_repo, shifts_repo, user_email=None, shift_id=None):
+        commitments_repo, shifts_repo, time_filter, user_email=None, shift_id=None):
     """
     Retrieves service commitments based on provided filters.
 
@@ -21,4 +21,22 @@ def list_service_commitments(
         user_email, shift_id)
     shift_ids = [commitment.service_shift_id for commitment in commitments]
     shifts = shifts_repo.get_shifts(shift_ids)
+
+    # additional filtering by time
+    for filter_key, comparison in [("start_after", lambda shift, value: shift.shift_start >= value),
+                                   ("start_before", lambda shift, value: shift.shift_start < value)]:
+        filter_value = time_filter.get_filter(filter_key)
+        print(filter_value)
+        if filter_value:
+            shift_ids = {
+                shift._id for shift in shifts if comparison(shift, filter_value)
+            }
+            print(shift_ids)
+            print(commitments)
+            commitments = [
+                commitment for commitment in commitments if commitment.service_shift_id in shift_ids
+            ]
+            print(commitments)
+            shifts = [shift for shift in shifts if shift._id in shift_ids]
+
     return (commitments, shifts)

--- a/server/use_cases/list_service_commitments.py
+++ b/server/use_cases/list_service_commitments.py
@@ -2,7 +2,11 @@
 This module contains the use case for listing service commitments.
 """
 def list_service_commitments(
-        commitments_repo, shifts_repo, time_filter, user_email=None, shift_id=None):
+        commitments_repo,
+        shifts_repo,
+        time_filter,
+        user_email=None,
+        shift_id=None):
     """
     Retrieves service commitments based on provided filters.
 
@@ -23,20 +27,18 @@ def list_service_commitments(
     shifts = shifts_repo.get_shifts(shift_ids)
 
     # additional filtering by time
-    for filter_key, comparison in [("start_after", lambda shift, value: shift.shift_start >= value),
-                                   ("start_before", lambda shift, value: shift.shift_start < value)]:
+    for filter_key, comparison in [
+        ("start_after", lambda shift, value: shift.shift_start >= value),
+        ("start_before", lambda shift, value: shift.shift_start < value)
+    ]:
         filter_value = time_filter.get_filter(filter_key)
-        print(filter_value)
         if filter_value:
             shift_ids = {
-                shift._id for shift in shifts if comparison(shift, filter_value)
+                s.get_id() for s in shifts if comparison(s, filter_value)
             }
-            print(shift_ids)
-            print(commitments)
             commitments = [
-                commitment for commitment in commitments if commitment.service_shift_id in shift_ids
+                c for c in commitments if c.service_shift_id in shift_ids
             ]
-            print(commitments)
-            shifts = [shift for shift in shifts if shift._id in shift_ids]
+            shifts = [shift for shift in shifts if shift.get_id() in shift_ids]
 
     return (commitments, shifts)


### PR DESCRIPTION
Fixes #268 

**What was changed?**

Updated GET /service_commitment API endpoint with optional parameters:
* filter_start_before=<MILLISECONDS_SINCE_EPOCH>
* filter_start_after=<MILLISECONDS_SINCE_EPOCH>

The endpoint will only return commitments that match these filtering parameters

**Why was it changed?**

This change was made to allow volunteers to differentiate between past and future commitments.

**How was it changed?**

I updated the list_service_commitments use case:
* it now expects a TimeFilter parameter
* If TimeFilter contains filter keys, it filters the service commitments (based on corresponding service shifts) according to those keys and their values

I also had to update the SerivceCommitment and ServiceShift structures, because the serivce_shift_id in ServiceCommitment was being stored as a string, while the _id of the ServiceShift was an ObjectId (from mongodb). This created a mismatch, when I was trying to match up filtered service shifts with corresponding service commitments. To convert from ObjectId to string, I changed MongoDb implementations of service commitments repo and service shifts repo.
