### PR TITLE
added DELETE /service_commitment/<COMMITMENT_ID> API endpoint

### DIFF
--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -200,8 +200,8 @@ def delete_service_commitment_by_id(commitment_id):
                 HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR],
             )
         response = delete_service_commitment(
-            commitments_repo, 
-            commitment_id, 
+            commitments_repo,
+            commitment_id,
             user_email)
         response_code = response["response_code"]
         # remove "response_code" from the response

--- a/server/application/rest/service_commitment.py
+++ b/server/application/rest/service_commitment.py
@@ -199,7 +199,10 @@ def delete_service_commitment_by_id(commitment_id):
                 jsonify({"error": "Invalid email format"}),
                 HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR],
             )
-        response = delete_service_commitment(commitments_repo, commitment_id, user_email)
+        response = delete_service_commitment(
+            commitments_repo, 
+            commitment_id, 
+            user_email)
         response_code = response["response_code"]
         # remove "response_code" from the response
         del response["response_code"]
@@ -207,7 +210,7 @@ def delete_service_commitment_by_id(commitment_id):
             json.dumps(response, default=str),
             mimetype="application/json",
             status=HTTP_STATUS_CODES_MAPPING[response_code])
-    
+
     except ValueError as error:
         return (
             jsonify({"error": str(error)}),

--- a/server/repository/mongo/service_commitments.py
+++ b/server/repository/mongo/service_commitments.py
@@ -3,6 +3,7 @@ Module for handling MongoDB operations related to service commitments.
 Provides methods to insert and fetch service commitments from the database.
 """
 
+from bson.objectid import ObjectId
 from config.mongodb_config import get_db
 from domains.service_commitment import ServiceCommitment
 
@@ -58,3 +59,30 @@ class MongoRepoCommitments:
                 filter=db_filter)
         ]
         return commitments
+    
+    def get_service_commitment_by_id(self, commitment_id):
+        """
+        Fetches a service commitment by its ID.
+
+        Args:
+            commitment_id (str): The ID of the service commitment.
+
+        Returns:
+            ServiceCommitment: The service commitment object.
+        """
+        commitment_object_id = ObjectId(commitment_id)
+        commitment = self.collection.find_one({"_id": commitment_object_id})
+        if commitment:
+            return ServiceCommitment.from_dict(commitment)
+        return None
+    
+    def delete_service_commitment(self, commitment_id):
+        """
+        Deletes a service commitment by its ID.
+
+        Args:
+            commitment_id (str): The ID of the service commitment to delete.
+        """
+        commitment_object_id = ObjectId(commitment_id)
+        result = self.collection.delete_one({"_id": commitment_object_id})
+        return result.deleted_count > 0

--- a/server/repository/mongo/service_commitments.py
+++ b/server/repository/mongo/service_commitments.py
@@ -59,7 +59,7 @@ class MongoRepoCommitments:
                 filter=db_filter)
         ]
         return commitments
-    
+
     def get_service_commitment_by_id(self, commitment_id):
         """
         Fetches a service commitment by its ID.
@@ -71,11 +71,11 @@ class MongoRepoCommitments:
             ServiceCommitment: The service commitment object.
         """
         commitment_object_id = ObjectId(commitment_id)
-        commitment = self.collection.find_one({"_id": commitment_object_id})
+        commitment = self.collection.find_one({'_id': commitment_object_id})
         if commitment:
             return ServiceCommitment.from_dict(commitment)
         return None
-    
+
     def delete_service_commitment(self, commitment_id):
         """
         Deletes a service commitment by its ID.
@@ -84,5 +84,5 @@ class MongoRepoCommitments:
             commitment_id (str): The ID of the service commitment to delete.
         """
         commitment_object_id = ObjectId(commitment_id)
-        result = self.collection.delete_one({"_id": commitment_object_id})
+        result = self.collection.delete_one({'_id': commitment_object_id})
         return result.deleted_count > 0

--- a/server/use_cases/delete_service_commitment.py
+++ b/server/use_cases/delete_service_commitment.py
@@ -23,8 +23,12 @@ def delete_service_commitment(commitments_repo, commitment_id, user_email):
         message = "User not authorized to delete this commitment"
     else:
         # Delete the commitment
-        commitments_repo.delete_service_commitment(commitment_id)
-        message = "Commitment deleted successfully"
+        result = commitments_repo.delete_service_commitment(commitment_id)
+        if result:
+            message = "Commitment deleted successfully"
+        else:
+            response_code = ResponseTypes.SYSTEM_ERROR
+            message = "Failed to delete commitment"
     response["response_code"] = response_code
     response["message"] = message
     return response

--- a/server/use_cases/delete_service_commitment.py
+++ b/server/use_cases/delete_service_commitment.py
@@ -1,0 +1,32 @@
+from responses import ResponseTypes
+def delete_service_commitment(commitments_repo, commitment_id, user_email):
+    """
+    Delete a service commitment by its ID.
+    """
+    try:
+        # Check if the commitment exists
+        commitment = commitments_repo.get_service_commitment_by_id(commitment_id)
+        response = {}
+        response["commitment_id"] = commitment_id
+        response_code = ResponseTypes.SUCCESS
+        if not commitment:
+            response_code = ResponseTypes.NOT_FOUND
+            message = "Commitment not found"
+
+        # Check if the user is authorized to delete the commitment
+        elif commitment.volunteer_id != user_email:
+            response_code = ResponseTypes.UNAUTHORIZED
+            message = "User not authorized to delete this commitment"
+        else:
+            # Delete the commitment
+            commitments_repo.delete_service_commitment(commitment_id)
+            message = "Commitment deleted successfully"
+        response["response_code"] = response_code
+        response["message"] = message
+        return response
+
+    except Exception as e:
+        return {
+            "response_code": ResponseTypes.SYSTEM_ERROR,
+            "message": str(e)
+        }

--- a/server/use_cases/delete_service_commitment.py
+++ b/server/use_cases/delete_service_commitment.py
@@ -1,32 +1,30 @@
+"""
+Use case for deleting a service commitment.
+"""
 from responses import ResponseTypes
 def delete_service_commitment(commitments_repo, commitment_id, user_email):
     """
     Delete a service commitment by its ID.
     """
-    try:
-        # Check if the commitment exists
-        commitment = commitments_repo.get_service_commitment_by_id(commitment_id)
-        response = {}
-        response["commitment_id"] = commitment_id
-        response_code = ResponseTypes.SUCCESS
-        if not commitment:
-            response_code = ResponseTypes.NOT_FOUND
-            message = "Commitment not found"
+    # Check if the commitment exists
+    commitment = commitments_repo.get_service_commitment_by_id(
+        commitment_id
+    )
+    response = {}
+    response["commitment_id"] = commitment_id
+    response_code = ResponseTypes.SUCCESS
+    if not commitment:
+        response_code = ResponseTypes.NOT_FOUND
+        message = "Commitment not found"
 
-        # Check if the user is authorized to delete the commitment
-        elif commitment.volunteer_id != user_email:
-            response_code = ResponseTypes.UNAUTHORIZED
-            message = "User not authorized to delete this commitment"
-        else:
-            # Delete the commitment
-            commitments_repo.delete_service_commitment(commitment_id)
-            message = "Commitment deleted successfully"
-        response["response_code"] = response_code
-        response["message"] = message
-        return response
-
-    except Exception as e:
-        return {
-            "response_code": ResponseTypes.SYSTEM_ERROR,
-            "message": str(e)
-        }
+    # Check if the user is authorized to delete the commitment
+    elif commitment.volunteer_id != user_email:
+        response_code = ResponseTypes.UNAUTHORIZED
+        message = "User not authorized to delete this commitment"
+    else:
+        # Delete the commitment
+        commitments_repo.delete_service_commitment(commitment_id)
+        message = "Commitment deleted successfully"
+    response["response_code"] = response_code
+    response["message"] = message
+    return response


### PR DESCRIPTION
Fixes #270

**What was changed?**

Added DELETE /service_commitment/<COMMITMENT_ID> API endpoint and supporting backend functionality: 
* Added use_cases/delete_service_commitment.py
* Updated mongo/service_commitments.py to include delete_service_commitment and get_commitment_by_id

**Why was it changed?**

This functionality is needed to allow volunteers to cancel their sign ups for shifts, if needed.