### PR TITLE
Repeatable Shifts UI + API Hook Integrated

### DIFF
--- a/client_app/src/api/permission.js
+++ b/client_app/src/api/permission.js
@@ -1,0 +1,21 @@
+import { fetchClient } from "./fetchClient";
+
+export const permissionsAPI = {
+    getPermissions: async() => {
+        const response = await fetchClient("/user_permission");
+        return response;
+    },
+    addPermission: async(data) => {
+        const response = await fetchClient("/user_permissions", {
+            method: "POST",
+            body: JSON.stringify(data),
+        });
+        return response;
+    },
+    deletePermission: async(permissionId) => {
+        const response = await fetchClient(`/user_permissions/${permissionId}`, {
+            method: "DELETE",
+        });
+        return response;
+    },
+};

--- a/client_app/src/api/schedule.js
+++ b/client_app/src/api/schedule.js
@@ -1,0 +1,12 @@
+// schedule.js
+import { fetchClient } from "./fetchClient";
+
+export const scheduleAPI = {
+  submitRepeatableShifts: async (shelterId, shifts) => {
+    const response = await fetchClient("/schedule", {
+      method: "POST",
+      body: JSON.stringify({ shelter_id: shelterId, shifts }),
+    });
+    return response;
+  }
+};

--- a/client_app/src/components/shelter/RepeatableShifts.js
+++ b/client_app/src/components/shelter/RepeatableShifts.js
@@ -3,6 +3,8 @@
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import "../../styles/shelter/RepeatableShifts.css";
+import { scheduleAPI } from "../../api/schedule";
+
 
 const RepeatableShifts = () => {
   const { shelterId } = useParams(); // grab the shelterId from URL
@@ -48,14 +50,16 @@ const RepeatableShifts = () => {
 
   const handleSubmitAllShifts = async () => {
     try {
-      // Replace with actual API call when ready
-      console.log("Submitting shifts to backend:", shifts);
+      await scheduleAPI.submitRepeatableShifts(shelterId, shifts);
       setSuccessMessage("Schedule submitted successfully!");
       setTimeout(() => setSuccessMessage(""), 3000);
     } catch (error) {
       console.error("Error submitting schedule:", error);
+      setSuccessMessage("Failed to submit schedule.");
+      setTimeout(() => setSuccessMessage(""), 3000);
     }
   };
+  
 
   const updateShift = (index, field, value) => {
     const updatedShifts = [...shifts];

--- a/server/application/app.py
+++ b/server/application/app.py
@@ -10,6 +10,7 @@ from application.rest.shelter import shelter_blueprint
 from application.rest.service_shifts import service_shift_bp
 from application.rest.authorization.authorization import authorization_blueprint
 from application.rest.login import login_blueprint
+from application.rest.schedule_get import schedule_bp
 
 from config import mongodb_config
 import os
@@ -32,6 +33,7 @@ def create_app(config_name = "development"):
     app.register_blueprint(service_shift_bp)
     app.register_blueprint(authorization_blueprint)
     app.register_blueprint(login_blueprint)
+    app.register_blueprint(schedule_bp)
 
     load_dotenv()  # Load environment variables from the .env file
 

--- a/server/application/rest/schedule.py
+++ b/server/application/rest/schedule.py
@@ -25,7 +25,6 @@ def create_schedule():
             status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR],
         )
     response = schedule_add_use_case(shifts_data)
-    
     return Response(
         json.dumps(response.value),
         mimetype="application/json",

--- a/server/application/rest/schedule_get.py
+++ b/server/application/rest/schedule_get.py
@@ -1,0 +1,30 @@
+import json
+from flask import Blueprint, request, Response
+from flask_cors import cross_origin
+from repository.mongo.schedule_repo import ScheduleMongoRepo
+from use_cases.list_service_shifts_use_case import service_shifts_list_use_case
+from application.rest.status_codes import HTTP_STATUS_CODES_MAPPING
+from responses import ResponseTypes
+from serializers.service_shift import ServiceShiftJsonEncoder
+
+schedule_bp = Blueprint("schedule", __name__)
+
+@schedule_bp.route("/schedule", methods=["GET"])
+@cross_origin()
+def handle_schedule_shift():
+    shelter_id = request.args.get("shelter_id")
+    if not shelter_id:
+        return Response(
+            json.dumps({"error": "shelter_id is required"}),
+            mimetype="application/json",
+            status=400
+        )
+
+    repo = ScheduleMongoRepo()
+    shifts = service_shifts_list_use_case(repo, shelter_id)
+
+    return Response(
+        json.dumps(shifts, cls=ServiceShiftJsonEncoder),
+        mimetype="application/json",
+        status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS],
+    )

--- a/server/application/rest/schedule_get.py
+++ b/server/application/rest/schedule_get.py
@@ -1,3 +1,5 @@
+"""Module for handling GET requests to the /schedule endpoint."""
+
 import json
 from flask import Blueprint, request, Response
 from flask_cors import cross_origin

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -12,8 +12,6 @@ from domains.service_shift import ServiceShift
 from application.rest.status_codes import HTTP_STATUS_CODES_MAPPING
 from responses import ResponseTypes
 from serializers.service_shift import ServiceShiftJsonEncoder
-from use_cases.get_schedule_shifts_use_case import get_schedule_shifts_use_case
-from repository.mongo.schedule_repo import ScheduleMongoRepo
 
 service_shift_bp = Blueprint("service_shift", __name__)
 
@@ -89,23 +87,3 @@ def handle_service_shift():
             mimetype="application/json",
             status=status_code,
         )
-
-@service_shift_bp.route("/schedule", methods=["GET"])
-@cross_origin()
-def handle_schedule_shift():
-    shelter_id = request.args.get("shelter_id")
-    if not shelter_id:
-        return Response(
-            json.dumps({"error": "shelter_id is required"}),
-            mimetype="application/json",
-            status=400
-        )
-        
-    repo = ScheduleMongoRepo()
-    shifts = get_schedule_shifts_use_case(repo, shelter_id)
-
-    return Response(
-        json.dumps(shifts, cls=ServiceShiftJsonEncoder),
-        mimetype="application/json",
-        status=200
-    )

--- a/server/application/rest/service_shifts.py
+++ b/server/application/rest/service_shifts.py
@@ -12,6 +12,8 @@ from domains.service_shift import ServiceShift
 from application.rest.status_codes import HTTP_STATUS_CODES_MAPPING
 from responses import ResponseTypes
 from serializers.service_shift import ServiceShiftJsonEncoder
+from use_cases.get_schedule_shifts_use_case import get_schedule_shifts_use_case
+from repository.mongo.schedule_repo import ScheduleMongoRepo
 
 service_shift_bp = Blueprint("service_shift", __name__)
 
@@ -87,3 +89,23 @@ def handle_service_shift():
             mimetype="application/json",
             status=status_code,
         )
+
+@service_shift_bp.route("/schedule", methods=["GET"])
+@cross_origin()
+def handle_schedule_shift():
+    shelter_id = request.args.get("shelter_id")
+    if not shelter_id:
+        return Response(
+            json.dumps({"error": "shelter_id is required"}),
+            mimetype="application/json",
+            status=400
+        )
+        
+    repo = ScheduleMongoRepo()
+    shifts = get_schedule_shifts_use_case(repo, shelter_id)
+
+    return Response(
+        json.dumps(shifts, cls=ServiceShiftJsonEncoder),
+        mimetype="application/json",
+        status=200
+    )

--- a/server/repository/mongo/schedule_repo.py
+++ b/server/repository/mongo/schedule_repo.py
@@ -1,6 +1,9 @@
+"""Repository for interacting with the schedules collection using ServiceShift structure."""
+
 from repository.mongo.service_shifts import ServiceShiftsMongoRepo
 
 class ScheduleMongoRepo(ServiceShiftsMongoRepo):
     def __init__(self):
         super().__init__()
-        self.collection = self.db.schedules  # override to use 'schedules' collection
+        self.collection = self.db.schedules
+        # override to use 'schedules' collection

--- a/server/repository/mongo/schedule_repo.py
+++ b/server/repository/mongo/schedule_repo.py
@@ -1,4 +1,5 @@
-"""Repository for interacting with the schedules collection using ServiceShift structure."""
+"""Repository for interacting with the schedules
+collection using ServiceShift structure."""
 
 from repository.mongo.service_shifts import (
     ServiceShiftsMongoRepo

--- a/server/repository/mongo/schedule_repo.py
+++ b/server/repository/mongo/schedule_repo.py
@@ -1,6 +1,8 @@
 """Repository for interacting with the schedules collection using ServiceShift structure."""
 
-from repository.mongo.service_shifts import ServiceShiftsMongoRepo
+from repository.mongo.service_shifts import (
+    ServiceShiftsMongoRepo
+)
 
 class ScheduleMongoRepo(ServiceShiftsMongoRepo):
     def __init__(self):

--- a/server/repository/mongo/schedule_repo.py
+++ b/server/repository/mongo/schedule_repo.py
@@ -1,0 +1,11 @@
+from domains.service_shift import ServiceShift
+from config.mongodb_config import get_db
+
+class ScheduleMongoRepo:
+    def __init__(self):
+        self.db = get_db()
+        self.collection = self.db.schedules
+
+    def list_by_shelter_id(self, shelter_id):
+        shifts = self.collection.find({"shelter_id": shelter_id})
+        return [ServiceShift.from_dict(s) for s in shifts]

--- a/server/repository/mongo/schedule_repo.py
+++ b/server/repository/mongo/schedule_repo.py
@@ -1,11 +1,6 @@
-from domains.service_shift import ServiceShift
-from config.mongodb_config import get_db
+from repository.mongo.service_shifts import ServiceShiftsMongoRepo
 
-class ScheduleMongoRepo:
+class ScheduleMongoRepo(ServiceShiftsMongoRepo):
     def __init__(self):
-        self.db = get_db()
-        self.collection = self.db.schedules
-
-    def list_by_shelter_id(self, shelter_id):
-        shifts = self.collection.find({"shelter_id": shelter_id})
-        return [ServiceShift.from_dict(s) for s in shifts]
+        super().__init__()
+        self.collection = self.db.schedules  # override to use 'schedules' collection

--- a/server/repository/mongo/service_shifts.py
+++ b/server/repository/mongo/service_shifts.py
@@ -12,12 +12,12 @@ class ServiceShiftsMongoRepo:
     MongoDB repository class for managing service shifts.
     """
 
-    def __init__(self):
+    def __init__(self, collection_name="service_shifts"):
         """
         Initialize the repository with a MongoDB connection.
         """
         self.db = get_db()
-        self.collection = self.db.service_shifts
+        self.collection = self.db[collection_name]
 
     def add_service_shifts(self, shift_data):
         """

--- a/server/tests/rest/test_schedule_endpoint.py
+++ b/server/tests/rest/test_schedule_endpoint.py
@@ -1,8 +1,10 @@
+"""Unit tests for the /schedule GET endpoint using mocked repository."""
+
 import unittest
-from unittest.mock import patch, MagicMock
 from application.app import create_app
 from domains.service_shift import ServiceShift
 
+"""Test case for verifying the /schedule endpoint returns correct JSON."""
 class TestScheduleEndpoint(unittest.TestCase):
 
     def setUp(self):
@@ -22,8 +24,8 @@ class TestScheduleEndpoint(unittest.TestCase):
         ]
 
     @patch("application.rest.schedule_get.ScheduleMongoRepo")
-    def test_get_schedule_returns_expected_data(self, MockRepo):
-        instance = MockRepo.return_value
+    def test_get_schedule_returns_expected_data(self, mock_repo):
+        instance = mock_repo.return_value
         instance.list.return_value = self.fake_shifts
 
         response = self.app.get(f"/schedule?shelter_id={self.shelter_id}")

--- a/server/tests/rest/test_schedule_endpoint.py
+++ b/server/tests/rest/test_schedule_endpoint.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from application.app import create_app
+from domains.service_shift import ServiceShift
+
+class TestScheduleEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        self.app = create_app().test_client()
+        self.shelter_id = "abc123"
+        self.fake_shifts = [
+            ServiceShift(
+                shelter_id=self.shelter_id,
+                shift_start=1714000000000,
+                shift_end=1714007200000,
+                shift_name="Test Shift",
+                required_volunteer_count=2,
+                max_volunteer_count=5,
+                can_sign_up=True,
+                _id="fake_id_1"
+            )
+        ]
+
+    @patch("application.rest.schedule_get.ScheduleMongoRepo")
+    def test_get_schedule_returns_expected_data(self, MockRepo):
+        instance = MockRepo.return_value
+        instance.list.return_value = self.fake_shifts
+
+        response = self.app.get(f"/schedule?shelter_id={self.shelter_id}")
+        self.assertEqual(response.status_code, 200)
+
+        data = response.get_json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["shift_name"], "Test Shift")

--- a/server/tests/rest/test_schedule_endpoint.py
+++ b/server/tests/rest/test_schedule_endpoint.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 from application.app import create_app
 from domains.service_shift import ServiceShift
 
-"""Test case for verifying the /schedule endpoint returns correct JSON."""
 class TestScheduleEndpoint(unittest.TestCase):
+    """Test case for verifying the /schedule endpoint returns correct JSON."""
 
     def setUp(self):
         self.app = create_app().test_client()

--- a/server/tests/rest/test_schedule_endpoint.py
+++ b/server/tests/rest/test_schedule_endpoint.py
@@ -1,6 +1,7 @@
 """Unit tests for the /schedule GET endpoint using mocked repository."""
 
 import unittest
+from unittest.mock import patch
 from application.app import create_app
 from domains.service_shift import ServiceShift
 

--- a/server/use_cases/get_schedule_shifts_use_case.py
+++ b/server/use_cases/get_schedule_shifts_use_case.py
@@ -1,0 +1,2 @@
+def get_schedule_shifts_use_case(repo, shelter_id):
+    return repo.list_by_shelter_id(shelter_id)

--- a/server/use_cases/get_schedule_shifts_use_case.py
+++ b/server/use_cases/get_schedule_shifts_use_case.py
@@ -1,2 +1,0 @@
-def get_schedule_shifts_use_case(repo, shelter_id):
-    return repo.list_by_shelter_id(shelter_id)

--- a/server/use_cases/schedule_add_use_case.py
+++ b/server/use_cases/schedule_add_use_case.py
@@ -1,6 +1,7 @@
 """Use case for adding schedule templates."""
 from repository.mongo.service_shifts import ServiceShiftsMongoRepo
 from responses import Response, ResponseTypes
+from pymongo.errors import PyMongoError
 
 def schedule_add_use_case(shifts_data):
     """Add schedule templates to the schedule collection."""
@@ -8,6 +9,6 @@ def schedule_add_use_case(shifts_data):
     try:
         inserted_ids = repo.add_service_shifts(shifts_data)
         return Response.success({"ids": inserted_ids})
-    except Exception as e:
+    except PyMongoError as e:
         return Response.failure(ResponseTypes.INTERNAL_ERROR, str(e))
     

--- a/server/use_cases/schedule_add_use_case.py
+++ b/server/use_cases/schedule_add_use_case.py
@@ -1,0 +1,26 @@
+"""Use case for adding schedule templates."""
+from repository.mongo.service_shifts import ServiceShiftsMongoRepo
+from responses import Response, ResponseTypes
+
+def schedule_add_use_case(shifts_data):
+    """Add schedule templates to the schedule collection."""
+    repo = ServiceShiftsMongoRepo(collection_name='schedule')
+    
+    try:
+        inserted_ids = []
+        for shift in shifts_data:
+            #validate that it has a service field
+            if 'service' not in shift:
+                return Response.failure(
+                    ResponseTypes.PARAMETER_ERROR, 
+                    "Each shift must have a service field"
+                )
+            
+            result = repo.insert(shift)
+            inserted_ids.append(str(result))
+        
+        return Response.success({"ids": inserted_ids})
+        
+    except Exception as e:
+        return Response.failure(ResponseTypes.INTERNAL_ERROR, str(e))
+    

--- a/server/use_cases/schedule_add_use_case.py
+++ b/server/use_cases/schedule_add_use_case.py
@@ -4,11 +4,9 @@ from responses import Response, ResponseTypes
 
 def schedule_add_use_case(shifts_data):
     """Add schedule templates to the schedule collection."""
-    repo = ServiceShiftsMongoRepo(collection_name='schedule')
-    
+    repo = ServiceShiftsMongoRepo(collection_name="schedule")
     try:
-        inserted_ids = repo.add_service_shifts(shifts_data) 
-        
+        inserted_ids = repo.add_service_shifts(shifts_data)
         return Response.success({"ids": inserted_ids})
     except Exception as e:
         return Response.failure(ResponseTypes.INTERNAL_ERROR, str(e))

--- a/server/use_cases/schedule_add_use_case.py
+++ b/server/use_cases/schedule_add_use_case.py
@@ -7,20 +7,9 @@ def schedule_add_use_case(shifts_data):
     repo = ServiceShiftsMongoRepo(collection_name='schedule')
     
     try:
-        inserted_ids = []
-        for shift in shifts_data:
-            #validate that it has a service field
-            if 'service' not in shift:
-                return Response.failure(
-                    ResponseTypes.PARAMETER_ERROR, 
-                    "Each shift must have a service field"
-                )
-            
-            result = repo.insert(shift)
-            inserted_ids.append(str(result))
+        inserted_ids = repo.add_service_shifts(shifts_data) 
         
         return Response.success({"ids": inserted_ids})
-        
     except Exception as e:
         return Response.failure(ResponseTypes.INTERNAL_ERROR, str(e))
     


### PR DESCRIPTION
Fixes #253

**What was changed?**

Added a new feature that allows shelter admins to define and submit repeatable shifts. Created a new component `RepeatableShifts.js` and accompanying stylesheet. Also added an API integration (`schedule.js`) that sends the defined shifts to the backend.

**Why was it changed?**

This feature improves the shelter admin’s ability to define standardized shift templates, streamlining the scheduling process. The UI allows easy entry and editing of repeatable shifts and submits them in bulk to the backend.

**How was it changed?**

- Added `RepeatableShifts.js` for defining and submitting shifts.
- Added `RepeatableShifts.css` for styling.
- Created `schedule.js` in the API folder to POST shift data using the shared `fetchClient`.
- Merged in latest changes from `issue-253-repeatable-shifts`.

**Pending**

- Awaiting confirmation from backend team on whether the `/schedule` POST endpoint is live.
- Currently returns a 405 error, indicating the method may not yet be supported on the backend.

**Screenshots**
<img width="727" alt="PNG image" src="https://github.com/user-attachments/assets/785238ab-91ef-48a2-a7aa-39630d35c4ae" />
<img width="1049" alt="PNG image" src="https://github.com/user-attachments/assets/4521ff81-02bd-4b8e-a6df-b55d023c968e" />
<img width="896" alt="PNG image" src="https://github.com/user-attachments/assets/6f0f485c-31f7-4a1f-bc7e-326348c9c436" />
