### PR TITLE
Issue 295

### DIFF
--- a/client_app/src/api/serviceShift.js
+++ b/client_app/src/api/serviceShift.js
@@ -10,6 +10,11 @@ export const serviceShiftAPI = {
         const response = await fetchClient(`/service_shift?filter_start_after=${timeNow}`);
         return response;
     },
+    getFutureShiftsForShelter: async(shelterId) => {
+        const timeNow = Date.now();
+        const response = await fetchClient(`/service_shift?shelter_id=${shelterId}&filter_start_after=${timeNow}`);
+        return response;
+    },
     addShifts: async(data) => {
         const response = await fetchClient("/service_shift", {
             method: "POST",

--- a/client_app/src/components/shelter/ShelterDashboard.js
+++ b/client_app/src/components/shelter/ShelterDashboard.js
@@ -75,7 +75,7 @@ function ShelterDashboard() {
               <h4>Understaffed Shifts</h4>
               <a href="/shift-details">View all</a>
             </div>
-            <UnderstaffedShifts />
+            <UnderstaffedShifts shelterId={shelterId} />
           </div>
           <div className="container-medium">
             <div className="container-align">

--- a/client_app/src/components/shelter/UnderstaffedShifts.js
+++ b/client_app/src/components/shelter/UnderstaffedShifts.js
@@ -5,7 +5,7 @@ import { serviceShiftAPI } from "../../api/serviceShift.js";
 const UnderstaffedShifts = ({shelterId}) => {
     const [shiftsData, setShiftsData] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
-
+    const [error, setError] = useState(null);
     useEffect(() => {
       const fetchShifts = async () => {
         try {
@@ -15,6 +15,7 @@ const UnderstaffedShifts = ({shelterId}) => {
         }
         catch (error) {
           console.error("Error fetching future shifts:", error);
+          setError("Failed to load future shifts: " + error.message);
           setIsLoading(false);
         }
       }
@@ -34,8 +35,12 @@ const UnderstaffedShifts = ({shelterId}) => {
           </div>
         ) : understaffedShifts.length > 0 ? (
           <ViewShifts shiftDetailsData={understaffedShifts} />
+        ) : error ? (
+          <div className="message error">
+            {error}
+          </div>
         ) : (
-          <div className="p-4 text-center text-gray-600">
+          <div className="message success">
             No understaffed shifts found.
           </div>
         )}

--- a/client_app/src/components/shelter/UnderstaffedShifts.js
+++ b/client_app/src/components/shelter/UnderstaffedShifts.js
@@ -1,18 +1,25 @@
-import { shiftDetailsData } from "./ShiftDetailsData.tsx";
+import { useState, useEffect } from "react";
 import ViewShifts from "./ViewShifts.js";
-import { useState } from "react";
-import { useEffect } from "react";
+import { serviceShiftAPI } from "../../api/serviceShift.js";
 
-const UnderstaffedShifts = () => {
+const UnderstaffedShifts = ({shelterId}) => {
     const [shiftsData, setShiftsData] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
-        // Simulate API fetch with setTimeout
-        setIsLoading(true);
-        setShiftsData(shiftDetailsData);
-        setIsLoading(false);
-    }, []);
+      const fetchShifts = async () => {
+        try {
+          const data = await serviceShiftAPI.getFutureShiftsForShelter(shelterId);
+          setShiftsData(data);
+          setIsLoading(false);
+        }
+        catch (error) {
+          console.error("Error fetching future shifts:", error);
+          setIsLoading(false);
+        }
+      }
+      fetchShifts();
+    }, [shelterId]);
     
     // Filter shiftsData to only include shifts that are understaffed
     const understaffedShifts = shiftsData.filter(shift => 

--- a/client_app/src/components/shelter/UpcomingShifts.js
+++ b/client_app/src/components/shelter/UpcomingShifts.js
@@ -1,14 +1,39 @@
-import { shiftDetailsData } from "./ShiftDetailsData.tsx";
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
 import ViewShifts from "./ViewShifts.js";
 import "../../styles/shelter/UpcomingShifts.css";
+import { serviceShiftAPI } from "../../api/serviceShift.js";
 
 const UpcomingShifts = () => {
+  const { shelterId } = useParams();
+  const [shiftDetailsData, setShiftDetailsData] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchShifts = async () => {
+      try {
+        const data = await serviceShiftAPI.getFutureShiftsForShelter(shelterId);
+        setShiftDetailsData(data);
+        setLoading(false);
+      } catch (error) {
+        console.error("Error fetching future shifts:", error);
+        setLoading(false);
+        //setError("Failed to load future shifts");
+      }
+    };
+    fetchShifts();
+  }, [shelterId]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <div className="upcoming-shifts">
       <h2>Upcoming Shifts</h2>
       <ViewShifts shiftDetailsData={shiftDetailsData} />
     </div>
   );
-}
+};
 
 export default UpcomingShifts;

--- a/client_app/src/components/shelter/ViewShifts.js
+++ b/client_app/src/components/shelter/ViewShifts.js
@@ -57,8 +57,13 @@ const ViewShifts = ({shiftDetailsData}) => {
   }, {});
 
   const sortedDates = Object.keys(shiftsGroupedByDate).sort(
-    (a, b) => a < b 
+    (a, b) => a < b
   );
+
+  // Sort shifts within each date by shift_start in ascending order
+  Object.keys(shiftsGroupedByDate).forEach((date) => {
+    shiftsGroupedByDate[date].sort((a, b) => a.shift_start - b.shift_start);
+  });
 
   return (
     <div className="upcoming-requests">

--- a/client_app/src/styles/index.css
+++ b/client_app/src/styles/index.css
@@ -754,3 +754,5 @@ button:disabled {
   text-align: left;
   flex: 1;
 }
+
+@import "./message.css";

--- a/client_app/src/styles/message.css
+++ b/client_app/src/styles/message.css
@@ -1,0 +1,17 @@
+.message {
+    padding: 10px;
+    margin-bottom: 20px;
+    border-radius: 4px;
+  }
+  
+  .message.success {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+  }
+  
+  .message.error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+  }


### PR DESCRIPTION
Fixes #295

**What was changed?**

Updated shelter dashboard to pull shifts with volunteers data from the server. These shifts and volunteers that signed up are now available in the main dashboard (Understaffed Shifts) and under the Upcoming Shifts menu item. A page refresh is required to get updated volunteer/shift data (if more volunteers sign up or un-sign up or of another admin changes shifts).

**Why was it changed?**

I made this change because shelter admins need visibility into what shifts are coming up in the future and who signed up to work those shifts.

**How was it changed?**

Added a `getFutureShiftsForShelter` function to the `src/api/serviceShift.js`. This function is now called from `src/components/shelter/UpcomingShifts.js` and `src/components/shelter/UnderstaffedShifts.js`. When the call is successful, data is displayed in the ViewShifts page. When unsuccessful, an error message is displayed.

