### PR TITLE
Issue 257

### DIFF
--- a/client_app/src/components/shelter/AddUserForm.js
+++ b/client_app/src/components/shelter/AddUserForm.js
@@ -46,15 +46,24 @@ const AddUserForm = ({ resourceType = "shelter" }) => {
         <h2>Add {adminType}</h2>
         <form onSubmit={handleSubmit}>
           <div className="form-group">
-            <label htmlFor="email">User Email</label>
-            <input
-              type="email"
-              id="email"
-              placeholder="Enter user email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
+            <label htmlFor="email" className="form-label">User Email</label>
+            <div className="input-group">
+              <input
+                type="email"
+                id="email"
+                placeholder="Enter user email"
+                value={email}
+                className="form-control"
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+              {
+                email.length > 0 &&
+                  <button type="button"
+                          onClick={() => setEmail("")}
+                          className="btn btn-warning m-0 w-auto px-3">Clear</button>
+              }
+            </div>
           </div>
           <button type="submit" className="submit-button">Add User</button>
         </form>


### PR DESCRIPTION
Fixes #257

**What was changed?**

A cancel button is added next to the email text input in AddUserForm.js.
Pressing the button clears the email text input. Button only shows up when 
email has characters; it is not disabled.

**Why was it changed?**

#257

**How was it changed?**

Email input field is wrapped in an input-group and a button is added to the input-group.

https://github.com/oss-slu/shelter_volunteers/blob/0bd4c28e73b971cd4598e82d38341bf8fc89b136/client_app/src/components/shelter/AddUserForm.js#L50-L66

**Screenshots that show the changes (if applicable):**

<img width="2098" height="348" alt="image" src="https://github.com/user-attachments/assets/d4372c89-3956-4f4a-842c-379dd396d832" />
