### PR TITLE
Fix shift sorting in volunteer dashboard

### DIFF
--- a/client_app/src/components/volunteer/Commitments.js
+++ b/client_app/src/components/volunteer/Commitments.js
@@ -92,6 +92,28 @@ function Commitments(){
     setResultMessage({});
   };
 
+  // Sort and format selected shifts for display
+  const sortedSelectedShifts = useMemo(() => {
+    return Array.from(selectedShifts)
+      .map(shiftId => {
+        const shift = shifts.find(s => s._id === shiftId);
+        return shift;
+      })
+      .filter(shift => shift) // Remove any undefined shifts
+      .sort((a, b) => new Date(a.shift_start).getTime() - new Date(b.shift_start).getTime()) // Sort chronologically
+      .map(shift => {
+        const shelter = shift.shelter;
+        const startTime = formatDateTime(shift.shift_start);
+        const endTime = formatDateTime(shift.shift_end);
+        return {
+          shift,
+          shelter,
+          startTime,
+          endTime
+        };
+      });
+  }, [selectedShifts, shifts]);
+
   if (loading) {
     return <Loading />;
   }
@@ -152,25 +174,11 @@ function Commitments(){
             Shifts Selected to Cancel ({selectedShifts.size})
           </h3>
           <div className="list">
-            {useMemo(() => {
-              return Array.from(selectedShifts)
-                .map(shiftId => {
-                  const shift = shifts.find(s => s._id === shiftId);
-                  return shift;
-                })
-                .filter(shift => shift) // Remove any undefined shifts
-                .sort((a, b) => new Date(a.shift_start).getTime() - new Date(b.shift_start).getTime()) // Sort chronologically
-                .map(shift => {
-                  const shelter = shift.shelter;
-                  const startTime = formatDateTime(shift.shift_start);
-                  const endTime = formatDateTime(shift.shift_end);
-                  return (
-                    <div key={shift._id} className="tagline-small">
-                      • {shelter.name} - on {startTime.date} at {startTime.time} - {endTime.time}
-                    </div>
-                  );
-                });
-            }, [selectedShifts, shifts])}
+            {sortedSelectedShifts.map(({ shift, shelter, startTime, endTime }) => (
+              <div key={shift._id} className="tagline-small">
+                • {shelter.name} - on {startTime.date} at {startTime.time} - {endTime.time}
+              </div>
+            ))}
           </div>
         </div>
         )}

--- a/client_app/src/components/volunteer/ShiftSignUp.js
+++ b/client_app/src/components/volunteer/ShiftSignUp.js
@@ -194,6 +194,28 @@ function VolunteerShiftSignup(){
     setShowResults(false);
   };
 
+  // Sort and format selected shifts for display
+  const sortedSelectedShifts = useMemo(() => {
+    return Array.from(selectedShifts)
+      .map(shiftId => {
+        const shift = shifts.find(s => s._id === shiftId);
+        return shift;
+      })
+      .filter(shift => shift) // Remove any undefined shifts
+      .sort((a, b) => new Date(a.shift_start).getTime() - new Date(b.shift_start).getTime()) // Sort chronologically
+      .map(shift => {
+        const shelter = shelterMap[shift.shelter_id];
+        const startTime = formatDateTime(shift.shift_start);
+        const endTime = formatDateTime(shift.shift_end);
+        return {
+          shift,
+          shelter,
+          startTime,
+          endTime
+        };
+      });
+  }, [selectedShifts, shifts, shelterMap]);
+
   if (loading) {
     return <Loading />;
   }
@@ -249,25 +271,11 @@ function VolunteerShiftSignup(){
             Selected Shifts ({selectedShifts.size})
           </h3>
           <div className="list">
-            {useMemo(() => {
-              return Array.from(selectedShifts)
-                .map(shiftId => {
-                  const shift = shifts.find(s => s._id === shiftId);
-                  return shift;
-                })
-                .filter(shift => shift) // Remove any undefined shifts
-                .sort((a, b) => new Date(a.shift_start).getTime() - new Date(b.shift_start).getTime()) // Sort chronologically
-                .map(shift => {
-                  const shelter = shelterMap[shift.shelter_id];
-                  const startTime = formatDateTime(shift.shift_start);
-                  const endTime = formatDateTime(shift.shift_end);
-                  return (
-                    <div key={shift._id} className="tagline-small">
-                      • {startTime.date} at {startTime.time} - {endTime.time} - {shelter.name}
-                    </div>
-                  );
-                });
-            }, [selectedShifts, shifts, shelterMap])}
+            {sortedSelectedShifts.map(({ shift, shelter, startTime, endTime }) => (
+              <div key={shift._id} className="tagline-small">
+                • {startTime.date} at {startTime.time} - {endTime.time} - {shelter.name}
+              </div>
+            ))}
           </div>
         </div>
         )}


### PR DESCRIPTION
Fixes #issue_305

**What was changed?**

The volunteer dashboard shift selection components were modified to improve user experience

**Why was it changed?**

selected shifts were displayed in the order they were selected rather than chronologically