### PR TITLE
Change 'Shelter Admin Dashboard' header to 'System Admin Dashboard'

### DIFF
--- a/client_app/src/components/admin/AdminDashboard.js
+++ b/client_app/src/components/admin/AdminDashboard.js
@@ -1,30 +1,28 @@
-import React, { useState } from 'react';
-import AddShelterForm from './AddShelterForm';
-import ShelterList from './ShelterList';
-import '../../styles/admin/AdminDashboard.css';
+import React, { useState } from "react";
+import AddShelterForm from "./AddShelterForm";
+import ShelterList from "./ShelterList";
+import "../../styles/admin/AdminDashboard.css";
 
 const AdminDashboard = () => {
-  const [activeTab, setActiveTab] = useState('add');
+  const [activeTab, setActiveTab] = useState("add");
   return (
     <div className="admin-dashboard">
-      <h1>Shelter Admin Dashboard</h1>
+      <h1>System Admin Dashboard</h1>
       <div className="tab-navigation">
-        <button 
-          className={`tab-button ${activeTab === 'add' ? 'active' : ''}`}
-          onClick={() => setActiveTab('add')}
-        >
+        <button
+          className={`tab-button ${activeTab === "add" ? "active" : ""}`}
+          onClick={() => setActiveTab("add")}>
           Add New Shelter
         </button>
-        <button 
-          className={`tab-button ${activeTab === 'view' ? 'active' : ''}`}
-          onClick={() => setActiveTab('view')}
-        >
+        <button
+          className={`tab-button ${activeTab === "view" ? "active" : ""}`}
+          onClick={() => setActiveTab("view")}>
           View All Shelters
         </button>
       </div>
       <div className="tab-content">
-        {activeTab === 'add' && <AddShelterForm />}
-        {activeTab === 'view' && <ShelterList />} 
+        {activeTab === "add" && <AddShelterForm />}
+        {activeTab === "view" && <ShelterList />}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #353

**What was changed?**

Changed 'Shelter Admin Dashboard' header to 'System Admin Dashboard'
in the system admin dashboard.

**Why was it changed?**

#353 

**How was it changed?**

innerHTML of first h1 in first div in AdminDashboard was edited.

**Screenshots that show the changes (if applicable):**

<img width="1495" height="757" alt="Screenshot 2025-11-02 at 2 34 40 PM" src="https://github.com/user-attachments/assets/8cbc6576-8fdd-4316-b142-77922ee70693" />


