### PR TITLE
Created Open Shelters List View

### DIFF
--- a/client_app/.eslintignore
+++ b/client_app/.eslintignore
@@ -1,0 +1,2 @@
+build/
+coverage/

--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -9,6 +9,7 @@ import PastCommitments from "./components/volunteer/PastCommitments";
 import Impact from "./components/volunteer/Impact";
 import VolunteerShiftSignup from "./components/volunteer/ShiftSignUp";
 import VolunteerProfile from "./components/volunteer/Profile"; // <-- NEW IMPORT
+import OpenSheltersCalendar from "./components/volunteer/OpenSheltersCalendar";
 
 // Common components
 import { DashboardProvider } from "./contexts/DashboardContext";
@@ -66,6 +67,7 @@ function AppContent() {
         </Route>
         <Route path="/volunteer-dashboard" element={<DashboardLayout />}>
           <Route index element={<DashboardContent />} />
+          <Route path="open-shelters-calendar" element={<OpenSheltersCalendar />} />
           <Route path="shelters" element={<VolunteerShiftSignup />} />
           <Route path="past-shifts" element={<PastCommitments />} />
           <Route path="upcoming-shifts" element={<Commitments />} />

--- a/client_app/src/components/NavigationConfig.js
+++ b/client_app/src/components/NavigationConfig.js
@@ -1,6 +1,7 @@
 import { faHome, faShield, faGear, faCalendar, faHeart, faClock } from '@fortawesome/free-solid-svg-icons';
 const navigationConfig = {
   volunteer: [
+    { icon: faCalendar, label: 'Open Shelters List', path: '/volunteer-dashboard/open-shelters-calendar', description: 'Browse upcoming open shelters grouped by date.' },
     { icon: faHeart, label: 'Sign Up to Help', path: '/volunteer-dashboard/shelters', description: 'Find shelters in need of volunteers and sign up to help.' },
     { icon: faClock, label: 'Upcoming Shifts', path: '/volunteer-dashboard/upcoming-shifts', description: 'View and manage your upcoming volunteering shifts.' },
     { icon: faShield, label: 'Past Shifts', path: '/volunteer-dashboard/past-shifts', description: 'Review your past volunteering activities and contributions.' },

--- a/client_app/src/components/shelter/ScheduleManager.js
+++ b/client_app/src/components/shelter/ScheduleManager.js
@@ -153,7 +153,7 @@ function ShelterScheduleManager() {
           required_volunteer_count: shift.requiredVolunteers,
           max_volunteer_count: shift.maxVolunteers,
           shift_name: shift.shiftName,
-          instructions: shift.instructionsRecurring ? (shift.instructions || "").trim() : "",
+          instructions: (shift.instructions || "").trim(),
         });
       });
     });

--- a/client_app/src/components/volunteer/Commitments.js
+++ b/client_app/src/components/volunteer/Commitments.js
@@ -153,46 +153,26 @@ function Commitments(){
             ? 'Here are your upcoming shifts. You can select shifts to cancel them.'
             : 'You have no upcoming shifts. Sign up through "Sign Up To Help" or use the calendar to view your schedule.'}
         </p>
-      </div>
-      {/* Desktop Table View */}
-      <div className="table-container desktop-only">
-        <table className="shifts-table">
-          <thead>
-            <tr className="table-header">
-              <th>Shelter</th>
-              <th>Date</th>
-              <th>Time</th>
-              <th>Duration</th>
-              <th>Shelter Instructions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {shifts.map((shift) => (
-              <DesktopShiftRow
-                key={shift._id}
-                shiftData={processShiftData(shift)}
-                handleShiftToggle={handleShiftToggle}
-                showInstructions={true}
-                isInstructionsOpen={expandedInstructions.has(shift._id)}
-                onInstructionsToggle={toggleInstructions}
-                instructionsColSpan={5}
-              />
-            ))}
-          </tbody>
-        </table>
-      </div>
-      {/* Mobile Card View */}
-      <div className="cards-container mobile-only">
-        {shifts.map((shift) => (
-          <MobileShiftCard
-            key={shift._id}
-            shiftData={processShiftData(shift)}
-            handleShiftToggle={handleShiftToggle}
-            showInstructions={true}
-            isInstructionsOpen={expandedInstructions.has(shift._id)}
-            onInstructionsToggle={toggleInstructions}
-          />
-        ))}
+        <div className="commitments-view-toggle" role="tablist" aria-label="Upcoming shifts view">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={viewMode === VIEW_LIST}
+            className={`commitments-view-btn ${viewMode === VIEW_LIST ? 'active' : ''}`}
+            onClick={() => setViewMode(VIEW_LIST)}
+          >
+            List
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={viewMode === VIEW_CALENDAR}
+            className={`commitments-view-btn ${viewMode === VIEW_CALENDAR ? 'active' : ''}`}
+            onClick={() => setViewMode(VIEW_CALENDAR)}
+          >
+            Calendar
+          </button>
+        </div>
       </div>
       <div className="sticky-signup-container">
         {selectedShifts.size > 0 && (
@@ -215,15 +195,15 @@ function Commitments(){
           </div>
         )}
         <div className="signup-section">
-          <button
-            type="button"
-            role="tab"
-            aria-selected={viewMode === VIEW_CALENDAR}
-            className={`commitments-view-btn ${viewMode === VIEW_CALENDAR ? 'active' : ''}`}
-            onClick={() => setViewMode(VIEW_CALENDAR)}
-          >
-            Calendar
-          </button>
+          {viewMode === VIEW_LIST && (
+            <button
+              onClick={handleCancel}
+              disabled={selectedShifts.size === 0}
+              className={`signup-button ${selectedShifts.size > 0 ? 'enabled signedup' : 'disabled'}`}
+            >
+              Cancel {selectedShifts.size} Shift{selectedShifts.size !== 1 ? 's' : ''}
+            </button>
+          )}
         </div>
       </div>
       {viewMode === VIEW_CALENDAR && (
@@ -240,11 +220,20 @@ function Commitments(){
                   <th>Date</th>
                   <th>Time</th>
                   <th>Duration</th>
+                  <th>Shelter Instructions</th>
                 </tr>
               </thead>
               <tbody>
                 {shifts.map((shift) => (
-                  <DesktopShiftRow key={shift._id} shiftData={processShiftData(shift)} handleShiftToggle={handleShiftToggle} />
+                  <DesktopShiftRow
+                    key={shift._id}
+                    shiftData={processShiftData(shift)}
+                    handleShiftToggle={handleShiftToggle}
+                    showInstructions={true}
+                    isInstructionsOpen={expandedInstructions.has(shift._id)}
+                    onInstructionsToggle={toggleInstructions}
+                    instructionsColSpan={5}
+                  />
                 ))}
               </tbody>
             </table>
@@ -252,38 +241,15 @@ function Commitments(){
           {/* Mobile Card View */}
           <div className="cards-container mobile-only">
             {shifts.map((shift) => (
-              <MobileShiftCard key={shift._id} shiftData={processShiftData(shift)} handleShiftToggle={handleShiftToggle} />
+              <MobileShiftCard
+                key={shift._id}
+                shiftData={processShiftData(shift)}
+                handleShiftToggle={handleShiftToggle}
+                showInstructions={true}
+                isInstructionsOpen={expandedInstructions.has(shift._id)}
+                onInstructionsToggle={toggleInstructions}
+              />
             ))}
-          </div>
-          <div className="sticky-signup-container">
-            {selectedShifts.size > 0 && (
-              <div className="selected-shifts-summary">
-                <h3 className="summary-title">
-                  Shifts Selected to Cancel ({selectedShifts.size})
-                </h3>
-                <div className="list">
-                  {sortedSelectedShifts.map(({ shift, shelter, startTime, endTime }) => (
-                    <div key={shift._id} className="tagline-small">
-                      • {shelter.name} - on {startTime.date} at {startTime.time} - {endTime.time}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-            {selectedShifts.size === 0 && (
-              <div>
-                <p className="tagline-small">You can select shifts you want to cancel.</p>
-              </div>
-            )}
-            <div className="signup-section">
-              <button
-                onClick={handleCancel}
-                disabled={selectedShifts.size === 0}
-                className={`signup-button ${selectedShifts.size > 0 ? 'enabled signedup' : 'disabled'}`}
-              >
-                Cancel {selectedShifts.size} Shift{selectedShifts.size !== 1 ? 's' : ''}
-              </button>
-            </div>
           </div>
         </>
       )}

--- a/client_app/src/components/volunteer/OpenSheltersCalendar.js
+++ b/client_app/src/components/volunteer/OpenSheltersCalendar.js
@@ -59,33 +59,38 @@ function OpenSheltersCalendar() {
         </div>
       )}
       {!loadError && (
-      <div className="open-shelters-calendar__results open-shelters-calendar__results--list">
-        <h2 className="open-shelters-calendar__results-title">Upcoming Open Shelters</h2>
-        <p className="tagline-small">
-          {openShelterGroups.length === 0
-            ? 'No upcoming open shelters are currently scheduled.'
-            : `${openShelterGroups.length} date${openShelterGroups.length === 1 ? '' : 's'} listed.`}
-        </p>
-        <div className="open-shelters-calendar__groups">
-          {openShelterGroups.map((group) => (
-            <section key={group.date.toISOString()} className="open-shelters-calendar__group">
-              <div className="open-shelters-calendar__group-header">
-                <h3 className="open-shelters-calendar__group-title">{formatDate(group.date)}</h3>
-                <span className="open-shelters-calendar__group-count">
-                  {group.shelters.length} shelter{group.shelters.length === 1 ? '' : 's'} open
-                </span>
-              </div>
-              <div className="open-shelters-calendar__cards">
-                {group.shelters.map((shelter) => (
-                  <article key={`${group.date.toISOString()}-${shelter._id}`} className="open-shelters-calendar__card">
-                    <ShelterInfo shelter={shelter} showLocation={Boolean(shelter?.address)} />
-                  </article>
-                ))}
-              </div>
-            </section>
-          ))}
+        <div className="open-shelters-calendar__results open-shelters-calendar__results--list">
+          <h2 className="open-shelters-calendar__results-title">Upcoming Open Shelters</h2>
+          <p className="tagline-small">
+            {openShelterGroups.length === 0
+              ? 'No upcoming open shelters are currently scheduled.'
+              : `${openShelterGroups.length} date${openShelterGroups.length === 1 ? '' : 's'} listed.`}
+          </p>
+          <div className="open-shelters-calendar__groups">
+            {openShelterGroups.map((group) => (
+              <section key={group.date.toISOString()} className="open-shelters-calendar__group">
+                <div className="open-shelters-calendar__group-header">
+                  <h3 className="open-shelters-calendar__group-title">
+                    {formatDate(group.date)}
+                  </h3>
+                  <span className="open-shelters-calendar__group-count">
+                    {group.shelters.length} shelter{group.shelters.length === 1 ? '' : 's'} open
+                  </span>
+                </div>
+                <div className="open-shelters-calendar__cards">
+                  {group.shelters.map((shelter) => (
+                    <article
+                      key={`${group.date.toISOString()}-${shelter._id}`}
+                      className="open-shelters-calendar__card"
+                    >
+                      <ShelterInfo shelter={shelter} showLocation={Boolean(shelter?.address)} />
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
         </div>
-      </div>
       )}
     </section>
   );

--- a/client_app/src/components/volunteer/OpenSheltersCalendar.js
+++ b/client_app/src/components/volunteer/OpenSheltersCalendar.js
@@ -11,9 +11,11 @@ function OpenSheltersCalendar() {
   const [shelters, setShelters] = useState([]);
   const [futureShifts, setFutureShifts] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
 
   useEffect(() => {
     const fetchCalendarData = async () => {
+      setLoadError('');
       try {
         const [shelterData, shiftData] = await Promise.all([
           shelterAPI.getShelters(),
@@ -24,6 +26,7 @@ function OpenSheltersCalendar() {
         setFutureShifts(shiftData);
       } catch (error) {
         console.error('Error loading open shelters calendar:', error);
+        setLoadError('We could not load the open shelters list right now. Please try again.');
       } finally {
         setLoading(false);
       }
@@ -49,6 +52,13 @@ function OpenSheltersCalendar() {
           Browse upcoming open shelters grouped by date in descending order.
         </p>
       </div>
+      {loadError && (
+        <div className="open-shelters-calendar__error" role="alert">
+          <h2 className="open-shelters-calendar__results-title">Unable to Load Shelters</h2>
+          <p className="tagline-small">{loadError}</p>
+        </div>
+      )}
+      {!loadError && (
       <div className="open-shelters-calendar__results open-shelters-calendar__results--list">
         <h2 className="open-shelters-calendar__results-title">Upcoming Open Shelters</h2>
         <p className="tagline-small">
@@ -76,6 +86,7 @@ function OpenSheltersCalendar() {
           ))}
         </div>
       </div>
+      )}
     </section>
   );
 }

--- a/client_app/src/components/volunteer/OpenSheltersCalendar.js
+++ b/client_app/src/components/volunteer/OpenSheltersCalendar.js
@@ -1,0 +1,83 @@
+import { useEffect, useMemo, useState } from 'react';
+import { shelterAPI } from '../../api/shelter';
+import { serviceShiftAPI } from '../../api/serviceShift';
+import Loading from '../Loading';
+import { formatDate } from '../../formatting/FormatDateTime';
+import { ShelterInfo } from './ShelterInfo';
+import { getOpenSheltersGroupedByDate } from '../../utils/openShelterCalendar';
+import '../../styles/volunteer/OpenSheltersCalendar.css';
+
+function OpenSheltersCalendar() {
+  const [shelters, setShelters] = useState([]);
+  const [futureShifts, setFutureShifts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCalendarData = async () => {
+      try {
+        const [shelterData, shiftData] = await Promise.all([
+          shelterAPI.getShelters(),
+          serviceShiftAPI.getFutureShifts(),
+        ]);
+
+        setShelters(shelterData);
+        setFutureShifts(shiftData);
+      } catch (error) {
+        console.error('Error loading open shelters calendar:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCalendarData();
+  }, []);
+
+  const openShelterGroups = useMemo(
+    () => getOpenSheltersGroupedByDate(shelters, futureShifts),
+    [futureShifts, shelters]
+  );
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  return (
+    <section className="open-shelters-calendar">
+      <div className="open-shelters-calendar__header">
+        <h1 className="title-small">Open Shelters List</h1>
+        <p className="tagline-small">
+          Browse upcoming open shelters grouped by date in descending order.
+        </p>
+      </div>
+      <div className="open-shelters-calendar__results open-shelters-calendar__results--list">
+        <h2 className="open-shelters-calendar__results-title">Upcoming Open Shelters</h2>
+        <p className="tagline-small">
+          {openShelterGroups.length === 0
+            ? 'No upcoming open shelters are currently scheduled.'
+            : `${openShelterGroups.length} date${openShelterGroups.length === 1 ? '' : 's'} listed.`}
+        </p>
+        <div className="open-shelters-calendar__groups">
+          {openShelterGroups.map((group) => (
+            <section key={group.date.toISOString()} className="open-shelters-calendar__group">
+              <div className="open-shelters-calendar__group-header">
+                <h3 className="open-shelters-calendar__group-title">{formatDate(group.date)}</h3>
+                <span className="open-shelters-calendar__group-count">
+                  {group.shelters.length} shelter{group.shelters.length === 1 ? '' : 's'} open
+                </span>
+              </div>
+              <div className="open-shelters-calendar__cards">
+                {group.shelters.map((shelter) => (
+                  <article key={`${group.date.toISOString()}-${shelter._id}`} className="open-shelters-calendar__card">
+                    <ShelterInfo shelter={shelter} showLocation={Boolean(shelter?.address)} />
+                  </article>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default OpenSheltersCalendar;

--- a/client_app/src/styles/volunteer/OpenSheltersCalendar.css
+++ b/client_app/src/styles/volunteer/OpenSheltersCalendar.css
@@ -1,0 +1,101 @@
+.open-shelters-calendar {
+  width: 100%;
+  text-align: left;
+}
+
+.open-shelters-calendar__header {
+  margin-bottom: 1.5rem;
+}
+
+.open-shelters-calendar__results {
+  background: #ffffff;
+  border: 1px solid #dbe4ee;
+  border-radius: 20px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  padding: 1.25rem;
+}
+
+.open-shelters-calendar__results-title {
+  margin: 0 0 0.5rem;
+  color: #0f172a;
+}
+
+.open-shelters-calendar__results--list {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.open-shelters-calendar__groups {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.open-shelters-calendar__group {
+  border: 1px solid #dbe4ee;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  padding: 1rem;
+}
+
+.open-shelters-calendar__group-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+  margin-bottom: 0.85rem;
+}
+
+.open-shelters-calendar__group-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.open-shelters-calendar__group-count {
+  color: #516072;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.open-shelters-calendar__cards {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.open-shelters-calendar__card {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 1rem;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+}
+
+.open-shelters-calendar__card .shelter-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 0.45rem;
+}
+
+.open-shelters-calendar__card .shelter-location a {
+  color: #1d4ed8;
+  text-decoration: none;
+  line-height: 1.6;
+}
+
+.open-shelters-calendar__card .shelter-location a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .open-shelters-calendar__results {
+    padding: 1rem;
+  }
+
+  .open-shelters-calendar__group-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+}

--- a/client_app/src/styles/volunteer/OpenSheltersCalendar.css
+++ b/client_app/src/styles/volunteer/OpenSheltersCalendar.css
@@ -15,6 +15,14 @@
   padding: 1.25rem;
 }
 
+.open-shelters-calendar__error {
+  background: #fff7ed;
+  border: 1px solid #fdba74;
+  border-radius: 20px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  padding: 1.25rem;
+}
+
 .open-shelters-calendar__results-title {
   margin: 0 0 0.5rem;
   color: #0f172a;

--- a/client_app/src/utils/openShelterCalendar.js
+++ b/client_app/src/utils/openShelterCalendar.js
@@ -1,0 +1,99 @@
+const isValidTimestamp = (value) => {
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime());
+};
+
+const getDayBounds = (dateValue) => {
+  const date = new Date(dateValue);
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+
+  const end = new Date(date);
+  end.setHours(23, 59, 59, 999);
+
+  return {
+    start: start.getTime(),
+    end: end.getTime(),
+  };
+};
+
+const toDateKey = (dateValue) => {
+  const date = new Date(dateValue);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export const getOpenShelterIdsForDate = (shifts, dateValue) => {
+  if (!Array.isArray(shifts) || !dateValue) {
+    return new Set();
+  }
+
+  const { start, end } = getDayBounds(dateValue);
+
+  return shifts.reduce((openShelterIds, shift) => {
+    if (!shift?.shelter_id || !isValidTimestamp(shift.shift_start)) {
+      return openShelterIds;
+    }
+
+    const shiftStart = new Date(shift.shift_start).getTime();
+    if (shiftStart >= start && shiftStart <= end) {
+      openShelterIds.add(shift.shelter_id);
+    }
+
+    return openShelterIds;
+  }, new Set());
+};
+
+export const getOpenSheltersForDate = (shelters, shifts, dateValue) => {
+  if (!Array.isArray(shelters) || shelters.length === 0) {
+    return [];
+  }
+
+  const openShelterIds = getOpenShelterIdsForDate(shifts, dateValue);
+
+  return shelters.filter((shelter) => openShelterIds.has(shelter._id));
+};
+
+export const getOpenSheltersGroupedByDate = (shelters, shifts) => {
+  if (!Array.isArray(shelters) || !Array.isArray(shifts)) {
+    return [];
+  }
+
+  const shelterMap = shelters.reduce((accumulator, shelter) => {
+    accumulator[shelter._id] = shelter;
+    return accumulator;
+  }, {});
+
+  const grouped = shifts.reduce((accumulator, shift) => {
+    if (!shift?.shelter_id || !isValidTimestamp(shift.shift_start)) {
+      return accumulator;
+    }
+
+    const shelter = shelterMap[shift.shelter_id];
+    if (!shelter) {
+      return accumulator;
+    }
+
+    const dateKey = toDateKey(shift.shift_start);
+    if (!accumulator[dateKey]) {
+      accumulator[dateKey] = {
+        date: new Date(shift.shift_start),
+        sheltersById: {},
+      };
+    }
+
+    accumulator[dateKey].sheltersById[shelter._id] = shelter;
+    return accumulator;
+  }, {});
+
+  return Object.values(grouped)
+    .sort((left, right) => right.date.getTime() - left.date.getTime())
+    .map((entry) => ({
+      date: entry.date,
+      shelters: Object.values(entry.sheltersById).sort((left, right) =>
+        (left.name || '').localeCompare(right.name || '')
+      ),
+    }));
+};

--- a/client_app/src/utils/openShelterCalendar.test.js
+++ b/client_app/src/utils/openShelterCalendar.test.js
@@ -1,0 +1,52 @@
+import {
+  getOpenShelterIdsForDate,
+  getOpenSheltersForDate,
+  getOpenSheltersGroupedByDate,
+} from './openShelterCalendar';
+
+describe('openShelterCalendar helpers', () => {
+  const shelters = [
+    { _id: 's1', name: 'Alpha Shelter' },
+    { _id: 's2', name: 'Bravo Shelter' },
+    { _id: 's3', name: 'Charlie Shelter' },
+  ];
+
+  const shifts = [
+    { shelter_id: 's1', shift_start: new Date('2026-04-15T09:00:00').getTime() },
+    { shelter_id: 's1', shift_start: new Date('2026-04-15T14:00:00').getTime() },
+    { shelter_id: 's2', shift_start: new Date('2026-04-15T11:30:00').getTime() },
+    { shelter_id: 's3', shift_start: new Date('2026-04-16T08:00:00').getTime() },
+    { shelter_id: 's3', shift_start: 'invalid' },
+  ];
+
+  it('returns unique shelter ids open on a selected day', () => {
+    const openShelterIds = getOpenShelterIdsForDate(shifts, new Date('2026-04-15T18:00:00'));
+
+    expect(Array.from(openShelterIds)).toEqual(['s1', 's2']);
+  });
+
+  it('returns only shelters open on the selected day', () => {
+    const openShelters = getOpenSheltersForDate(shelters, shifts, new Date('2026-04-16T10:00:00'));
+
+    expect(openShelters).toEqual([{ _id: 's3', name: 'Charlie Shelter' }]);
+  });
+
+  it('returns an empty array when no shelters are open on the selected day', () => {
+    const openShelters = getOpenSheltersForDate(shelters, shifts, new Date('2026-04-18T10:00:00'));
+
+    expect(openShelters).toEqual([]);
+  });
+
+  it('groups shelters by date in descending order without duplicates for the same day', () => {
+    const groupedShelters = getOpenSheltersGroupedByDate(shelters, shifts);
+
+    expect(groupedShelters).toHaveLength(2);
+    expect(groupedShelters[0].date.toISOString()).toContain('2026-04-16');
+    expect(groupedShelters[0].shelters).toEqual([{ _id: 's3', name: 'Charlie Shelter' }]);
+    expect(groupedShelters[1].date.toISOString()).toContain('2026-04-15');
+    expect(groupedShelters[1].shelters).toEqual([
+      { _id: 's1', name: 'Alpha Shelter' },
+      { _id: 's2', name: 'Bravo Shelter' },
+    ]);
+  });
+});

--- a/client_app/src/utils/openShelterCalendar.test.js
+++ b/client_app/src/utils/openShelterCalendar.test.js
@@ -37,6 +37,44 @@ describe('openShelterCalendar helpers', () => {
     expect(openShelters).toEqual([]);
   });
 
+  it('returns an empty array when shelters are null or undefined', () => {
+    expect(getOpenSheltersForDate(null, shifts, new Date('2026-04-15T10:00:00'))).toEqual([]);
+    expect(getOpenSheltersGroupedByDate(undefined, shifts)).toEqual([]);
+  });
+
+  it('returns an empty set or array when shifts are empty', () => {
+    expect(Array.from(getOpenShelterIdsForDate([], new Date('2026-04-15T10:00:00')))).toEqual([]);
+    expect(getOpenSheltersGroupedByDate(shelters, [])).toEqual([]);
+  });
+
+  it('includes shelters whose shifts start at the exact day boundaries', () => {
+    const boundaryShifts = [
+      { shelter_id: 's1', shift_start: new Date('2026-04-20T00:00:00').getTime() },
+      { shelter_id: 's2', shift_start: new Date('2026-04-20T23:59:59.999').getTime() },
+      { shelter_id: 's3', shift_start: new Date('2026-04-21T00:00:00').getTime() },
+    ];
+
+    const openShelterIds = getOpenShelterIdsForDate(
+      boundaryShifts,
+      new Date('2026-04-20T12:00:00')
+    );
+
+    expect(Array.from(openShelterIds)).toEqual(['s1', 's2']);
+  });
+
+  it('deduplicates repeated shelter ids for the same day', () => {
+    const duplicateShifts = [
+      { shelter_id: 's1', shift_start: new Date('2026-04-22T08:00:00').getTime() },
+      { shelter_id: 's1', shift_start: new Date('2026-04-22T12:00:00').getTime() },
+      { shelter_id: 's1', shift_start: new Date('2026-04-22T16:00:00').getTime() },
+    ];
+
+    const groupedShelters = getOpenSheltersGroupedByDate(shelters, duplicateShifts);
+
+    expect(groupedShelters).toHaveLength(1);
+    expect(groupedShelters[0].shelters).toEqual([{ _id: 's1', name: 'Alpha Shelter' }]);
+  });
+
   it('groups shelters by date in descending order without duplicates for the same day', () => {
     const groupedShelters = getOpenSheltersGroupedByDate(shelters, shifts);
 
@@ -48,5 +86,20 @@ describe('openShelterCalendar helpers', () => {
       { _id: 's1', name: 'Alpha Shelter' },
       { _id: 's2', name: 'Bravo Shelter' },
     ]);
+  });
+
+  it('handles larger datasets while preserving descending date order', () => {
+    const largeShifts = Array.from({ length: 120 }, (_, index) => ({
+      shelter_id: shelters[index % shelters.length]._id,
+      shift_start: new Date(
+        `2026-05-${String((index % 20) + 1).padStart(2, '0')}T08:00:00`
+      ).getTime(),
+    }));
+
+    const groupedShelters = getOpenSheltersGroupedByDate(shelters, largeShifts);
+
+    expect(groupedShelters).toHaveLength(20);
+    expect(groupedShelters[0].date.getTime()).toBeGreaterThan(groupedShelters[1].date.getTime());
+    expect(groupedShelters[19].date.getTime()).toBeLessThan(groupedShelters[0].date.getTime());
   });
 });


### PR DESCRIPTION
Fixes #393

What was changed?

Updated the volunteer dashboard experience for open shelters and related volunteer scheduling flows. The volunteer-facing open-shelters feature was changed from a calendar-based picker into a list-based view grouped by date, and the upcoming-shifts screen was cleaned up to remove the duplicate legacy table. I also adjusted shelter shift creation so typed instructions are preserved when creating shifts.

Why was it changed?

Issue #393 asked for a simple list view where volunteers can browse upcoming open shelters without interacting with a calendar or filters. The previous implementation required clicking a date, which did not match the story. The updated version fixes that by automatically showing upcoming open shelters grouped by date in descending order. While validating the flow, I also fixed two related UX/behavior issues: weekday visibility in the prior open-shelters UI, duplicate upcoming-shifts tables, and instructions being dropped when creating shifts unless a recurring toggle was enabled.

How was it changed?

Modified client_app/src/components/volunteer/OpenSheltersCalendar.js to replace the calendar interaction with a grouped, scrollable list of open shelters by date. Updated client_app/src/utils/openShelterCalendar.js to add grouping and descending-date sorting logic, and extended client_app/src/utils/openShelterCalendar.test.js to cover that behavior. Refreshed client_app/src/styles/volunteer/OpenSheltersCalendar.css so the page matches the new list layout. Updated client_app/src/components/NavigationConfig.js so the volunteer nav label now reflects the list-based feature.

Also cleaned up client_app/src/components/volunteer/Commitments.js by removing the older duplicated upcoming-shifts table and keeping a single list/calendar flow. In client_app/src/components/shelter/ScheduleManager.js, changed shift creation so instructions are saved on created shifts even when the recurring-instructions toggle is off.

<img width="1160" height="730" alt="Screenshot 2026-04-13 at 11 28 18 AM" src="https://github.com/user-attachments/assets/3231e073-424d-43a0-8352-b147fcaedd4d" />