### PR TITLE
Worked on issue 404 shelter staff frontend

### DIFF
--- a/client_app/src/App.js
+++ b/client_app/src/App.js
@@ -24,6 +24,7 @@ import AddUserForm from "./components/shelter/AddUserForm";
 import UpcomingShifts from "./components/shelter/UpcomingShifts";
 import Settings from "./components/shelter/Settings";
 import ShelterScheduleManager from "./components/shelter/ScheduleManager";
+import OpenSheltersList from "./components/shelter/OpenSheltersList";
 // Admin dashboard components
 import AdminDashboard from "./components/admin/AdminDashboard";
 
@@ -59,6 +60,7 @@ function AppContent() {
         <Route path="/shelter-dashboard/:shelterId" element={<DashboardLayout />}>
           <Route index element={<DashboardContent />} />
           <Route path="settings" element={<Settings />} />
+          <Route path="open-shelters-list" element={<OpenSheltersList />} />
           <Route path="schedule" element={<ShelterScheduleManager />} />
           <Route path="upcoming-shifts" element={<UpcomingShifts />} />
           <Route path="repeatable-shifts" element={<RepeatableShiftsScreen />} />

--- a/client_app/src/components/NavigationConfig.js
+++ b/client_app/src/components/NavigationConfig.js
@@ -8,6 +8,7 @@ const navigationConfig = {
   ],
   shelter: [
     { icon: faGear, label: 'Users', path: '/shelter-dashboard/:ID/users', description: 'View, add, or remove other shelter admins.' },
+    { icon: faCalendar, label: 'Open Shelters List', path: '/shelter-dashboard/:ID/open-shelters-list', description: 'Browse upcoming open shelters grouped by date.' },
     { icon: faCalendar, label: 'Daily Schedule', path: '/shelter-dashboard/:ID/repeatable-shifts', description: 'Create and manage a schedule that will be used when you open a shelter.' },
     { icon: faCalendar, label: 'Open Shelter', path: '/shelter-dashboard/:ID/schedule', description: 'Select days when the shelter will be open and define volunteering shifts.' },
     { icon: faClock, label: 'Upcoming Shifts', path: '/shelter-dashboard/:ID/upcoming-shifts' }

--- a/client_app/src/components/shelter/OpenSheltersList.js
+++ b/client_app/src/components/shelter/OpenSheltersList.js
@@ -4,7 +4,7 @@ import { serviceShiftAPI } from '../../api/serviceShift';
 import Loading from '../Loading';
 import { formatDate } from '../../formatting/FormatDateTime';
 import { ShelterInfo } from '../volunteer/ShelterInfo';
-import { getOpenSheltersGroupedByDate } from '../../utils/openSheltersByDate';
+import { getOpenSheltersGroupedByDate, toDateKey } from '../../utils/openSheltersByDate';
 import '../../styles/shelter/OpenSheltersList.css';
 
 function OpenSheltersList() {
@@ -14,24 +14,38 @@ function OpenSheltersList() {
   const [loadError, setLoadError] = useState('');
 
   useEffect(() => {
+    let isMounted = true;
+
     const fetchOpenShelters = async () => {
-      setLoadError('');
+      if (isMounted) {
+        setLoadError('');
+      }
       try {
         const [shelterData, shiftData] = await Promise.all([
           shelterAPI.getShelters(),
           serviceShiftAPI.getFutureShifts(),
         ]);
-        setShelters(shelterData);
-        setFutureShifts(shiftData);
+        if (isMounted) {
+          setShelters(shelterData);
+          setFutureShifts(shiftData);
+        }
       } catch (error) {
         console.error('Error loading shelter dashboard open shelters list:', error);
-        setLoadError('We could not load the open shelters list right now. Please try again.');
+        if (isMounted) {
+          setLoadError('We could not load the open shelters list right now. Please try again.');
+        }
       } finally {
-        setLoading(false);
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     };
 
     fetchOpenShelters();
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const openShelterGroups = useMemo(
@@ -67,7 +81,7 @@ function OpenSheltersList() {
           </p>
           <div className="shelter-open-list__groups">
             {openShelterGroups.map((group) => (
-              <section key={group.date.toISOString()} className="shelter-open-list__group">
+              <section key={toDateKey(group.date)} className="shelter-open-list__group">
                 <div className="shelter-open-list__group-header">
                   <h3 className="shelter-open-list__group-title">{formatDate(group.date)}</h3>
                   <span className="shelter-open-list__group-count">

--- a/client_app/src/components/shelter/OpenSheltersList.js
+++ b/client_app/src/components/shelter/OpenSheltersList.js
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useState } from 'react';
+import { shelterAPI } from '../../api/shelter';
+import { serviceShiftAPI } from '../../api/serviceShift';
+import Loading from '../Loading';
+import { formatDate } from '../../formatting/FormatDateTime';
+import { ShelterInfo } from '../volunteer/ShelterInfo';
+import { getOpenSheltersGroupedByDate } from '../../utils/openSheltersByDate';
+import '../../styles/shelter/OpenSheltersList.css';
+
+function OpenSheltersList() {
+  const [shelters, setShelters] = useState([]);
+  const [futureShifts, setFutureShifts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+
+  useEffect(() => {
+    const fetchOpenShelters = async () => {
+      setLoadError('');
+      try {
+        const [shelterData, shiftData] = await Promise.all([
+          shelterAPI.getShelters(),
+          serviceShiftAPI.getFutureShifts(),
+        ]);
+        setShelters(shelterData);
+        setFutureShifts(shiftData);
+      } catch (error) {
+        console.error('Error loading shelter dashboard open shelters list:', error);
+        setLoadError('We could not load the open shelters list right now. Please try again.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchOpenShelters();
+  }, []);
+
+  const openShelterGroups = useMemo(
+    () => getOpenSheltersGroupedByDate(shelters, futureShifts),
+    [futureShifts, shelters]
+  );
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  return (
+    <section className="shelter-open-list">
+      <div className="shelter-open-list__header">
+        <h1 className="title-small">Open Shelters List</h1>
+        <p className="tagline-small">
+          Browse upcoming open shelters grouped by date in descending order.
+        </p>
+      </div>
+      {loadError && (
+        <div className="shelter-open-list__error" role="alert">
+          <h2 className="shelter-open-list__results-title">Unable to Load Shelters</h2>
+          <p className="tagline-small">{loadError}</p>
+        </div>
+      )}
+      {!loadError && (
+        <div className="shelter-open-list__results shelter-open-list__results--list">
+          <h2 className="shelter-open-list__results-title">Upcoming Open Shelters</h2>
+          <p className="tagline-small">
+            {openShelterGroups.length === 0
+              ? 'No upcoming open shelters are currently scheduled.'
+              : `${openShelterGroups.length} date${openShelterGroups.length === 1 ? '' : 's'} listed.`}
+          </p>
+          <div className="shelter-open-list__groups">
+            {openShelterGroups.map((group) => (
+              <section key={group.date.toISOString()} className="shelter-open-list__group">
+                <div className="shelter-open-list__group-header">
+                  <h3 className="shelter-open-list__group-title">{formatDate(group.date)}</h3>
+                  <span className="shelter-open-list__group-count">
+                    {group.shelters.length} shelter{group.shelters.length === 1 ? '' : 's'} open
+                  </span>
+                </div>
+                <div className="shelter-open-list__cards">
+                  {group.shelters.map((shelter) => (
+                    <article
+                      key={`${group.date.toISOString()}-${shelter._id}`}
+                      className="shelter-open-list__card"
+                    >
+                      <ShelterInfo shelter={shelter} showLocation={Boolean(shelter?.address)} />
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default OpenSheltersList;

--- a/client_app/src/styles/shelter/OpenSheltersList.css
+++ b/client_app/src/styles/shelter/OpenSheltersList.css
@@ -1,0 +1,109 @@
+.shelter-open-list {
+  width: 100%;
+  text-align: left;
+}
+
+.shelter-open-list__header {
+  margin-bottom: 1.5rem;
+}
+
+.shelter-open-list__results {
+  background: #ffffff;
+  border: 1px solid #dbe4ee;
+  border-radius: 20px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  padding: 1.25rem;
+}
+
+.shelter-open-list__error {
+  background: #fff7ed;
+  border: 1px solid #fdba74;
+  border-radius: 20px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  padding: 1.25rem;
+}
+
+.shelter-open-list__results-title {
+  margin: 0 0 0.5rem;
+  color: #0f172a;
+}
+
+.shelter-open-list__results--list {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.shelter-open-list__groups {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.shelter-open-list__group {
+  border: 1px solid #dbe4ee;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  padding: 1rem;
+}
+
+.shelter-open-list__group-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+  margin-bottom: 0.85rem;
+}
+
+.shelter-open-list__group-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.shelter-open-list__group-count {
+  color: #516072;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.shelter-open-list__cards {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.shelter-open-list__card {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 1rem;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+}
+
+.shelter-open-list__card .shelter-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 0.45rem;
+}
+
+.shelter-open-list__card .shelter-location a {
+  color: #1d4ed8;
+  text-decoration: none;
+  line-height: 1.6;
+}
+
+.shelter-open-list__card .shelter-location a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .shelter-open-list__results {
+    padding: 1rem;
+  }
+
+  .shelter-open-list__group-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+}

--- a/client_app/src/utils/openSheltersByDate.js
+++ b/client_app/src/utils/openSheltersByDate.js
@@ -3,7 +3,7 @@ const isValidTimestamp = (value) => {
   return !Number.isNaN(date.getTime());
 };
 
-const toDateKey = (dateValue) => {
+export const toDateKey = (dateValue) => {
   const date = new Date(dateValue);
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');

--- a/client_app/src/utils/openSheltersByDate.js
+++ b/client_app/src/utils/openSheltersByDate.js
@@ -1,0 +1,54 @@
+const isValidTimestamp = (value) => {
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime());
+};
+
+const toDateKey = (dateValue) => {
+  const date = new Date(dateValue);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export const getOpenSheltersGroupedByDate = (shelters, shifts) => {
+  if (!Array.isArray(shelters) || !Array.isArray(shifts)) {
+    return [];
+  }
+
+  const shelterMap = shelters.reduce((accumulator, shelter) => {
+    accumulator[shelter._id] = shelter;
+    return accumulator;
+  }, {});
+
+  const grouped = shifts.reduce((accumulator, shift) => {
+    if (!shift?.shelter_id || !isValidTimestamp(shift.shift_start)) {
+      return accumulator;
+    }
+
+    const shelter = shelterMap[shift.shelter_id];
+    if (!shelter) {
+      return accumulator;
+    }
+
+    const dateKey = toDateKey(shift.shift_start);
+    if (!accumulator[dateKey]) {
+      accumulator[dateKey] = {
+        date: new Date(shift.shift_start),
+        sheltersById: {},
+      };
+    }
+
+    accumulator[dateKey].sheltersById[shelter._id] = shelter;
+    return accumulator;
+  }, {});
+
+  return Object.values(grouped)
+    .sort((left, right) => right.date.getTime() - left.date.getTime())
+    .map((entry) => ({
+      date: entry.date,
+      shelters: Object.values(entry.sheltersById).sort((left, right) =>
+        (left.name || '').localeCompare(right.name || '')
+      ),
+    }));
+};

--- a/client_app/src/utils/openSheltersByDate.test.js
+++ b/client_app/src/utils/openSheltersByDate.test.js
@@ -1,0 +1,35 @@
+import { getOpenSheltersGroupedByDate } from './openSheltersByDate';
+
+describe('openSheltersByDate helpers', () => {
+  const shelters = [
+    { _id: 's1', name: 'Alpha Shelter' },
+    { _id: 's2', name: 'Bravo Shelter' },
+    { _id: 's3', name: 'Charlie Shelter' },
+  ];
+
+  it('groups shelters by date in descending order without duplicates for the same day', () => {
+    const shifts = [
+      { shelter_id: 's1', shift_start: new Date('2026-04-15T09:00:00').getTime() },
+      { shelter_id: 's1', shift_start: new Date('2026-04-15T14:00:00').getTime() },
+      { shelter_id: 's2', shift_start: new Date('2026-04-15T11:30:00').getTime() },
+      { shelter_id: 's3', shift_start: new Date('2026-04-16T08:00:00').getTime() },
+      { shelter_id: 's3', shift_start: 'invalid' },
+    ];
+
+    const groupedShelters = getOpenSheltersGroupedByDate(shelters, shifts);
+
+    expect(groupedShelters).toHaveLength(2);
+    expect(groupedShelters[0].date.toISOString()).toContain('2026-04-16');
+    expect(groupedShelters[0].shelters).toEqual([{ _id: 's3', name: 'Charlie Shelter' }]);
+    expect(groupedShelters[1].date.toISOString()).toContain('2026-04-15');
+    expect(groupedShelters[1].shelters).toEqual([
+      { _id: 's1', name: 'Alpha Shelter' },
+      { _id: 's2', name: 'Bravo Shelter' },
+    ]);
+  });
+
+  it('returns an empty array when shelters or shifts are missing', () => {
+    expect(getOpenSheltersGroupedByDate(undefined, [])).toEqual([]);
+    expect(getOpenSheltersGroupedByDate(shelters, null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #404

What was changed?

Added a new list-based view to the shelter dashboard that shows open shelters grouped by date in descending order. This mirrors the volunteer-side experience but is now available to shelter administrators inside their own dashboard. I also added a shared frontend utility for grouping shelters by date, a test for that helper, a new shelter dashboard page component, and the route/navigation needed to access it.

Why was it changed?

Issue #404 asked for a simple way for shelter administrators to browse all upcoming open shelters without needing to use a calendar or filters. The existing shelter dashboard focused on managing a single shelter’s schedule, but it did not provide a unified list view across dates. This change fixes that by adding a clean, scrollable page that groups open shelters by date in descending order and displays each shelter’s name and location details.

How was it changed?

Created client_app/src/components/shelter/OpenSheltersList.js to fetch shelter and future shift data, build grouped results with useMemo, and render the shelter dashboard list view with loading and error states. Added matching styles in client_app/src/styles/shelter/OpenSheltersList.css for the grouped cards, scrollable layout, and fallback UI.

Created client_app/src/utils/openSheltersByDate.js to centralize the grouping logic. That helper validates timestamps, groups shelters by calendar date, removes duplicates for the same date, and sorts the date groups in descending order. Added client_app/src/utils/openSheltersByDate.test.js to verify descending grouping and deduplication behavior.

Updated client_app/src/components/NavigationConfig.js so the shelter dashboard now includes an Open Shelters List navigation item. Updated client_app/src/App.js to register the new shelter dashboard route at /shelter-dashboard/:shelterId/open-shelters-list.

<img width="1592" height="865" alt="Screenshot 2026-04-18 at 3 12 02 PM" src="https://github.com/user-attachments/assets/9ca39dfe-2ecf-4e40-88b3-75dba326c1e5" />