### PR TITLE
Worked on issue 405 shelter staff backend

### DIFF
--- a/server/application/rest/shelter.py
+++ b/server/application/rest/shelter.py
@@ -20,13 +20,6 @@ from application.rest.system_admin_permission_required import system_admin_permi
 from domains.shelter.shelter import Shelter
 from responses import ResponseTypes
 from serializers.shelter import ShelterJsonEncoder
-from use_cases.list_service_shifts_use_case import service_shifts_list_use_case
-from use_cases.shelters.add_shelter_use_case import shelter_add_use_case
-from use_cases.shelters.get_shelter_by_id import get_shelter_by_id
-from use_cases.shelters.list_shelters_use_case import shelter_list_use_case
-from use_cases.shelters.list_open_shelters_by_date_use_case import (
-    list_open_shelters_by_date_use_case,
-)
 
 shelter_blueprint = Blueprint("shelter", __name__)
 

--- a/server/application/rest/shelter.py
+++ b/server/application/rest/shelter.py
@@ -3,16 +3,25 @@ This module contains the RESTful route handlers
 for shelters in the server application.
 """
 import json
+import time
+
 from flask import Blueprint, Response, request
+
 from repository.mongo.shelter import ShelterRepo
-from use_cases.shelters.add_shelter_use_case import shelter_add_use_case
-from use_cases.shelters.get_shelter_by_id import get_shelter_by_id
-from use_cases.shelters.list_shelters_use_case import shelter_list_use_case
+from repository.mongo.service_shifts import ServiceShiftsMongoRepo
+
 from application.rest.status_codes import HTTP_STATUS_CODES_MAPPING
 from application.rest.system_admin_permission_required import system_admin_permission_required
 from domains.shelter.shelter import Shelter
-from serializers.shelter import ShelterJsonEncoder
 from responses import ResponseTypes
+from serializers.shelter import ShelterJsonEncoder
+from use_cases.list_service_shifts_use_case import service_shifts_list_use_case
+from use_cases.shelters.add_shelter_use_case import shelter_add_use_case
+from use_cases.shelters.get_shelter_by_id import get_shelter_by_id
+from use_cases.shelters.list_shelters_use_case import shelter_list_use_case
+from use_cases.shelters.list_open_shelters_by_date_use_case import (
+    list_open_shelters_by_date_use_case,
+)
 
 shelter_blueprint = Blueprint("shelter", __name__)
 
@@ -32,6 +41,25 @@ def get_shelters():
     )
     return Response(
         shelters_as_json,
+        mimetype="application/json",
+        status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
+    )
+
+
+@shelter_blueprint.route("/shelters/open", methods=["GET"])
+def get_open_shelters_grouped_by_date():
+    """Return future open shelters grouped by date in descending order."""
+    shelters = shelter_list_use_case(repo)
+    current_time_ms = int(time.time() * 1000)
+    service_shifts_repo = ServiceShiftsMongoRepo()
+    service_shifts = service_shifts_list_use_case(
+        service_shifts_repo,
+        filter_start_after=current_time_ms,
+    )
+    grouped_shelters = list_open_shelters_by_date_use_case(shelters, service_shifts)
+
+    return Response(
+        json.dumps(grouped_shelters),
         mimetype="application/json",
         status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
     )

--- a/server/tests/rest/shelter/test_shelter.py
+++ b/server/tests/rest/shelter/test_shelter.py
@@ -2,26 +2,32 @@
 This module contains tests for the shelter REST API.
 """
 import json
-import pytest
+from unittest.mock import ANY, patch
 
-from unittest.mock import patch
+import pytest
 from flask import Flask
+
+from authentication.token import create_token
 from application.rest.shelter import shelter_blueprint
 from domains.shelter.shelter import Shelter
-from authentication.token import create_token
+from domains.service_shift import ServiceShift
 
 test_secret = "test_secret"
+
+
 def create_test_app():
     app = Flask(__name__)
     app.register_blueprint(shelter_blueprint)
     app.config["JWT_SECRET"] = test_secret
     return app
 
+
 @pytest.fixture
 def client():
     app = create_test_app()
     app.config["TESTING"] = True
     return app.test_client()
+
 
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
@@ -30,8 +36,8 @@ def client():
 def test_post_shelter(
     mock_is_authorized,
     mock_shelter_add_use_case,
-    client
-    ):
+    client,
+):
     mock_is_authorized.return_value = True
     mock_response = {
         "id": "SOME_ID",
@@ -55,62 +61,61 @@ def test_post_shelter(
 
     token = create_token({"email": "user@app.com"}, test_secret)
     headers = {
-        "Authorization": f"{token}"
+        "Authorization": f"{token}",
     }
 
     response = client.post(
         "/shelters",
         data=json.dumps(request_data),
         content_type="application/json",
-        headers=headers
+        headers=headers,
     )
 
     assert response.status_code == 200
     assert response.json == mock_response
 
 @patch("application.rest.system_admin_permission_required.is_authorized")
-def test_post_shelter_missing_required_fields(
-    mock_is_authorized, client):
+def test_post_shelter_missing_required_fields(mock_is_authorized, client):
     mock_is_authorized.return_value = True
     request_data = {
-        "name": "Test shelter" #missing address field
+        "name": "Test shelter",  # missing address field
     }
     token = create_token({"email": "user@app.com"}, test_secret)
     headers = {
-        "Authorization": f"{token}"
+        "Authorization": f"{token}",
     }
     response = client.post(
         "/shelters",
         data=json.dumps(request_data),
         content_type="application/json",
-        headers=headers
+        headers=headers,
     )
-    assert response.status_code == 400 #bad request
+    assert response.status_code == 400  # bad request
     assert not response.json["success"]
     assert "address" in response.json["message"]
     request_data = {
         "name": "Test shelter",
         "address": {
             "city": "St.Louis",
-            "state": "MO", #missing street1
-        }
+            "state": "MO",  # missing street1
+        },
     }
 
     response = client.post(
         "/shelters",
         data=json.dumps(request_data),
         content_type="application/json",
-        headers=headers
+        headers=headers,
     )
-    assert response.status_code == 400 #bad request
+    assert response.status_code == 400  # bad request
     assert not response.json["success"]
     assert "street1" in response.json["message"]
     request_data = {
         "name": "Test shelter",
         "address": {
             "street1": "123 Main",
-            "state": "MO", #missing city
-        }
+            "state": "MO",  # missing city
+        },
     }
     response = client.post(
         "/shelters",
@@ -118,23 +123,23 @@ def test_post_shelter_missing_required_fields(
         content_type="application/json",
         headers=headers
     )
-    assert response.status_code == 400  #bad request
+    assert response.status_code == 400  # bad request
     assert not response.json["success"]
     assert "city" in response.json["message"]
     request_data = {
         "name": "Test shelter",
         "address": {
             "street1": "123 Main",
-            "city": "St.Louis", #missing state
-        }
+            "city": "St.Louis",  # missing state
+        },
     }
     response = client.post(
         "/shelters",
         data=json.dumps(request_data),
         content_type="application/json",
-        headers=headers
+        headers=headers,
     )
-    assert response.status_code == 400  #bad request
+    assert response.status_code == 400  # bad request
     assert not response.json["success"]
     assert "state" in response.json["message"]
 
@@ -168,10 +173,7 @@ def test_get_shelter(mock_shelter_list_use_case, client):
             },
         },
     ]
-    mock_shelters = [
-        Shelter.from_dict(shelter)
-        for shelter in mock_shelters_json
-    ]
+    mock_shelters = [Shelter.from_dict(shelter) for shelter in mock_shelters_json]
 
     mock_shelter_list_use_case.return_value = mock_shelters
     response = client.get("/shelters")
@@ -179,5 +181,115 @@ def test_get_shelter(mock_shelter_list_use_case, client):
     parsed_response = json.loads(raw_data)
     assert response.status_code == 200
     assert parsed_response == mock_shelters_json
+
+
+@patch("application.rest.shelter.time.time", return_value=1760000000)
+@patch("application.rest.shelter.service_shifts_list_use_case")
+@patch("application.rest.shelter.shelter_list_use_case")
+def test_get_open_shelters_grouped_by_date(
+    mock_shelter_list_use_case,
+    mock_service_shifts_list_use_case,
+    mock_time,
+    client,
+):
+    assert mock_time is not None
+    mock_shelters = [
+        Shelter.from_dict({
+            "_id": "s1",
+            "name": "Shelter One",
+            "address": {
+                "street1": "456 Elm St",
+                "street2": "",
+                "city": "Springfield",
+                "state": "IL",
+                "postal_code": "62701",
+                "country": "USA",
+                "coordinates": {"latitude": 39.7817, "longitude": -89.6501},
+            },
+        }),
+        Shelter.from_dict({
+            "_id": "s2",
+            "name": "Shelter Two",
+            "address": {
+                "street1": "789 Oak St",
+                "street2": "",
+                "city": "Chicago",
+                "state": "IL",
+                "postal_code": "60616",
+                "country": "USA",
+                "coordinates": {"latitude": 41.8781, "longitude": -87.6298},
+            },
+        }),
+    ]
+    for shelter, shelter_id in zip(mock_shelters, ["s1", "s2"]):
+        shelter.set_id(shelter_id)
+
+    mock_shifts = [
+        ServiceShift(
+            shelter_id="s1",
+            shift_start=1776470400000,
+            shift_end=1776474000000,
+        ),
+        ServiceShift(
+            shelter_id="s1",
+            shift_start=1776477600000,
+            shift_end=1776481200000,
+        ),
+        ServiceShift(
+            shelter_id="s2",
+            shift_start=1776384000000,
+            shift_end=1776387600000,
+        ),
+    ]
+
+    mock_shelter_list_use_case.return_value = mock_shelters
+    mock_service_shifts_list_use_case.return_value = mock_shifts
+
+    response = client.get("/shelters/open")
+    parsed_response = json.loads(response.data.decode())
+
+    assert response.status_code == 200
+    assert parsed_response == [
+        {
+            "date": "2026-04-18",
+            "shelters": [
+                {
+                    "_id": "s1",
+                    "name": "Shelter One",
+                    "address": {
+                        "street1": "456 Elm St",
+                        "street2": "",
+                        "city": "Springfield",
+                        "state": "IL",
+                        "postal_code": "62701",
+                        "country": "USA",
+                        "coordinates": {"latitude": 39.7817, "longitude": -89.6501},
+                    },
+                },
+            ],
+        },
+        {
+            "date": "2026-04-17",
+            "shelters": [
+                {
+                    "_id": "s2",
+                    "name": "Shelter Two",
+                    "address": {
+                        "street1": "789 Oak St",
+                        "street2": "",
+                        "city": "Chicago",
+                        "state": "IL",
+                        "postal_code": "60616",
+                        "country": "USA",
+                        "coordinates": {"latitude": 41.8781, "longitude": -87.6298},
+                    },
+                },
+            ],
+        },
+    ]
+    mock_service_shifts_list_use_case.assert_called_once_with(
+        ANY,
+        filter_start_after=1760000000000,
+    )
 # pylint: enable=unused-argument
 # pylint: enable=redefined-outer-name

--- a/server/use_cases/shelters/list_open_shelters_by_date_use_case.py
+++ b/server/use_cases/shelters/list_open_shelters_by_date_use_case.py
@@ -1,0 +1,50 @@
+"""Build a grouped list of open shelters by date."""
+
+import json
+from datetime import datetime, timezone
+
+from serializers.shelter import ShelterJsonEncoder
+
+
+def _date_key_from_timestamp(timestamp_ms):
+    shift_datetime = datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
+    return shift_datetime.strftime("%Y-%m-%d")
+
+
+def _serialize_shelter(shelter):
+    return json.loads(json.dumps(shelter, cls=ShelterJsonEncoder))
+
+
+def list_open_shelters_by_date_use_case(shelters, service_shifts):
+    """Group open shelters by UTC date in descending order.
+
+    The response excludes shift-level details and includes each shelter
+    at most once per date.
+    """
+    shelters_by_id = {str(shelter.get_id()): shelter for shelter in shelters}
+    grouped_shelters = {}
+
+    for shift in service_shifts:
+        shelter_id = str(shift.shelter_id)
+        shelter = shelters_by_id.get(shelter_id)
+        if shelter is None:
+            continue
+
+        date_key = _date_key_from_timestamp(shift.shift_start)
+        if date_key not in grouped_shelters:
+            grouped_shelters[date_key] = {}
+
+        grouped_shelters[date_key][shelter_id] = _serialize_shelter(shelter)
+
+    grouped_list = []
+    for date_key in sorted(grouped_shelters.keys(), reverse=True):
+        shelters_for_date = sorted(
+            grouped_shelters[date_key].values(),
+            key=lambda shelter: shelter.get("name", ""),
+        )
+        grouped_list.append({
+            "date": date_key,
+            "shelters": shelters_for_date,
+        })
+
+    return grouped_list


### PR DESCRIPTION
Fixes #405

**What was changed?**

Added a new backend/API endpoint to support the shelter dashboard open shelters list view. The backend now returns upcoming open shelters grouped by date in descending order in a single response, along with lightweight shelter metadata such as name and location. I also added the supporting backend grouping logic and REST test coverage for the new endpoint.

**Why was it changed?**

Issue #405 asked for a more efficient way for the shelter dashboard to retrieve open shelter availability across upcoming dates without relying on multiple requests or frontend-side grouping. This change fixes that by moving the grouping, sorting, and deduplication into the backend. As a result, the shelter dashboard can receive a response that is already structured for the list view, reducing frontend complexity and making the data flow easier to maintain.

**How was it changed?**

Created [server/use_cases/shelters/list_open_shelters_by_date_use_case.py](/Users/orhankoylu/Desktop/Capstone/shelter_volunteers/server/use_cases/shelters/list_open_shelters_by_date_use_case.py) to group future service shifts by UTC date, deduplicate shelters per day, sort those dates in descending order, and serialize only the shelter metadata needed by the frontend. Updated [server/application/rest/shelter.py](/Users/orhankoylu/Desktop/Capstone/shelter_volunteers/server/application/rest/shelter.py) to add the new `GET /shelters/open` route. That route gathers all shelters, filters future service shifts using the current timestamp, and returns the grouped response for the shelter dashboard.

I also updated [server/tests/rest/shelter/test_shelter.py](/Users/orhankoylu/Desktop/Capstone/shelter_volunteers/server/tests/rest/shelter/test_shelter.py) to add coverage for the new endpoint. The new test verifies the response shape, confirms that dates are returned in descending order, checks that duplicate shifts for the same shelter on the same day only produce one shelter entry, and confirms that the shift list use case is called with the expected future-only timestamp filter.