### PR TITLE
removed shelter id

### DIFF
--- a/client_app/src/components/shelter/RepeatableShiftsScreen.js
+++ b/client_app/src/components/shelter/RepeatableShiftsScreen.js
@@ -108,7 +108,7 @@ const RepeatableShiftsScreen = () => {
       <div>
         <h1 className="display-4">Repeatable Shifts</h1>
         <h2>
-          Shelter: {loadingShelterName ? "Loading Shelter Name" : shelterName} ({shelterId})
+          Shelter: {loadingShelterName ? "Loading Shelter Name" : shelterName}
         </h2>
       </div>
       {errorMessages.length > 0 && (


### PR DESCRIPTION
Fixes #409

What was changed?

Updated the Repeatable Shifts screen in the shelter dashboard so it no longer displays the internal shelter ID next to the shelter name. The page still shows the shelter name, but the backend/database identifier is hidden from the user interface.

Why was it changed?

The Repeatable Shifts screen was showing the shelter’s internal ID in the page header. This was not useful for end users and could expose internal implementation details. Removing the ID makes the UI cleaner, more user-friendly, and avoids displaying unnecessary internal data.

How was it changed?

Modified client_app/src/components/shelter/RepeatableShiftsScreen.js. In the header section, the shelter label previously rendered both the shelter name and shelterId in parentheses. I removed the ({shelterId}) portion so the screen now only renders:

Shelter: {loadingShelterName ? "Loading Shelter Name" : shelterName}

The shelterId is still kept in the component and used internally for API calls, but it is no longer displayed to users.

<img width="1585" height="711" alt="Screenshot 2026-04-18 at 8 27 25 PM" src="https://github.com/user-attachments/assets/5eef22c7-76b2-4b8c-8dbf-788250f62574" />